### PR TITLE
Migrate from Navigation2 to Navigation3 and update Target SDK to 36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
 
     implementation(libs.activity.compose)
     implementation(libs.compose.hilt.navigation)
-    implementation(libs.compose.navigation)
+    implementation(libs.lifecycle.viewmodel.navigation3)
 
     implementation(libs.splash)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:theme="@style/Theme.App.Splash"
         tools:targetApi="31">
         <activity
+            android:enableOnBackInvokedCallback="true"
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"

--- a/app/src/main/java/com/matijasokol/githubapp/navigation/NavigationEffect.kt
+++ b/app/src/main/java/com/matijasokol/githubapp/navigation/NavigationEffect.kt
@@ -4,30 +4,28 @@ package com.matijasokol.githubapp.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
-import androidx.navigation.NavHostController
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import com.matijasokol.coreui.events.ObserveAsEvent
 
 val LocalNavigator = compositionLocalOf<Navigator> { error("Navigator not provided") }
 val LocalNavigatorErrorMapper = compositionLocalOf<NavigationErrorMapper> { error("NavigatorErrorMapper not provided") }
 
 @Composable
-fun NavigationEffect(navController: NavHostController) {
+fun NavigationEffect(backStack: NavBackStack<NavKey>) {
     val navigator = LocalNavigator.current
 
-    ObserveAsEvent(navigator.navigationEvent, navController) {
-        executeNavigationRequests(navController, it)
+    ObserveAsEvent(navigator.navigationEvent, backStack) {
+        executeNavigationRequests(backStack, it)
     }
 }
 
 private fun executeNavigationRequests(
-    navController: NavHostController,
+    backStack: NavBackStack<NavKey>,
     navigationEvent: NavigationEvent,
 ) {
     when (navigationEvent) {
-        is NavigationEvent.Destination<*> -> navController.navigate(
-            route = navigationEvent.route as Any,
-            builder = navigationEvent.builder,
-        )
-        NavigationEvent.NavigateUp -> navController.navigateUp()
+        is NavigationEvent.Destination<*> -> backStack.add(navigationEvent.route)
+        NavigationEvent.GoBack -> backStack.removeLastOrNull()
     }
 }

--- a/app/src/main/java/com/matijasokol/githubapp/navigation/NavigationEvent.kt
+++ b/app/src/main/java/com/matijasokol/githubapp/navigation/NavigationEvent.kt
@@ -1,13 +1,8 @@
 package com.matijasokol.githubapp.navigation
 
-import androidx.navigation.NavOptionsBuilder
-
 sealed interface NavigationEvent {
 
-    data object NavigateUp : NavigationEvent
+    data object GoBack : NavigationEvent
 
-    data class Destination<T : com.matijasokol.coreui.navigation.Destination>(
-        val route: T,
-        val builder: NavOptionsBuilder.() -> Unit = {},
-    ) : NavigationEvent
+    data class Destination<T : com.matijasokol.coreui.navigation.Destination>(val route: T) : NavigationEvent
 }

--- a/app/src/main/java/com/matijasokol/githubapp/navigation/Navigator.kt
+++ b/app/src/main/java/com/matijasokol/githubapp/navigation/Navigator.kt
@@ -8,6 +8,4 @@ interface Navigator {
     val navigationEvent: Flow<NavigationEvent>
 
     suspend fun emitDestination(event: NavigationEvent): Either<NavigationError, Unit>
-
-    fun tryEmitDestination(event: NavigationEvent): Either<NavigationError, Unit>
 }

--- a/app/src/main/java/com/matijasokol/githubapp/navigation/NavigatorImpl.kt
+++ b/app/src/main/java/com/matijasokol/githubapp/navigation/NavigatorImpl.kt
@@ -17,10 +17,6 @@ class NavigatorImpl @Inject constructor(private val canShowDetailsUseCase: CanSh
     override suspend fun emitDestination(event: NavigationEvent): Either<NavigationError, Unit> =
         isEligibleDestination(event).onRight { _navigationEvent.send(event) }
 
-    override fun tryEmitDestination(event: NavigationEvent): Either<NavigationError, Unit> =
-        isEligibleDestination(event).onRight { _navigationEvent.trySend(event) }
-
-    @Suppress("DuplicateCaseInWhenExpression")
     private fun isEligibleDestination(event: NavigationEvent): Either<NavigationError, Unit> =
         when (event) {
             is Destination<*> if (event.route is RepoDetail && !canShowDetailsUseCase()) ->

--- a/app/src/main/java/com/matijasokol/githubapp/ui/AppContent.kt
+++ b/app/src/main/java/com/matijasokol/githubapp/ui/AppContent.kt
@@ -2,12 +2,14 @@ package com.matijasokol.githubapp.ui
 
 import android.content.Context
 import android.widget.Toast
+import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
@@ -16,18 +18,18 @@ import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
-import com.matijasokol.coreui.components.LocalAnimatedContentScope
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
 import com.matijasokol.coreui.components.LocalSharedTransitionScope
 import com.matijasokol.coreui.events.ObserveAsEvent
 import com.matijasokol.coreui.navigation.Destination
@@ -44,13 +46,13 @@ import com.matijasokol.repo.list.RepoList
 import com.matijasokol.repo.list.RepoListAction
 import com.matijasokol.repo.list.RepoListAction.NavigateToDetails
 import com.matijasokol.repo.list.RepoListViewModel
+import kotlinx.coroutines.launch
 
 @Composable
 fun AppContent(
     navigator: Navigator,
     navigatorErrorMapper: NavigationErrorMapper,
     modifier: Modifier = Modifier,
-    navController: NavHostController = rememberNavController(),
 ) {
     Scaffold(
         modifier = modifier,
@@ -62,7 +64,7 @@ fun AppContent(
                 LocalNavigator provides navigator,
                 LocalNavigatorErrorMapper provides navigatorErrorMapper,
             ) {
-                NavigationContent(navController = navController)
+                NavigationContent()
             }
         }
     }
@@ -70,109 +72,94 @@ fun AppContent(
 
 @Composable
 private fun NavigationContent(
-    navController: NavHostController,
     modifier: Modifier = Modifier,
 ) {
-    NavigationEffect(navController = navController)
+    val backStack = rememberNavBackStack(Destination.RepoList)
+    val scope = rememberCoroutineScope()
+    val navigator = LocalNavigator.current
 
-    NavHost(
+    NavigationEffect(backStack = backStack)
+
+    NavDisplay(
         modifier = modifier,
-        navController = navController,
-        startDestination = Destination.RepoList,
-    ) {
-        repoList()
-        repoDetail()
-    }
+        backStack = backStack,
+        onBack = {
+            scope.launch {
+                navigator.emitDestination(NavigationEvent.GoBack)
+            }
+        },
+        entryDecorators = listOf(
+            rememberSaveableStateHolderNavEntryDecorator(),
+            rememberViewModelStoreNavEntryDecorator(),
+        ),
+        transitionSpec = { slideTransition(enterFromLeft = false) },
+        popTransitionSpec = { slideTransition(enterFromLeft = true) },
+        predictivePopTransitionSpec = { slideTransition(enterFromLeft = true) },
+        entryProvider = entryProvider {
+            entry<Destination.RepoList> {
+                RepoListEntry()
+            }
+            entry<Destination.RepoDetail> { key ->
+                RepoDetailEntry(key)
+            }
+        },
+    )
 }
 
-private fun NavGraphBuilder.repoList() {
-    composable<Destination.RepoList>(
-        popEnterTransition = {
-            slideInHorizontally(
-                animationSpec = tween(durationMillis = NAVIGATION_ANIMATION_DURATION),
-                initialOffsetX = { fullWidth -> -fullWidth },
-            ) + fadeIn(animationSpec = tween(durationMillis = NAVIGATION_ANIMATION_DURATION))
-        },
-        exitTransition = {
-            slideOutHorizontally(
-                animationSpec = tween(durationMillis = NAVIGATION_ANIMATION_DURATION),
-                targetOffsetX = { fullWidth -> -fullWidth },
-            ) + fadeOut(animationSpec = tween(durationMillis = NAVIGATION_ANIMATION_DURATION))
-        },
-    ) {
-        val viewModel: RepoListViewModel = hiltViewModel()
-        val state by viewModel.state.collectAsStateWithLifecycle()
+@Composable
+private fun RepoListEntry() {
+    val viewModel: RepoListViewModel = hiltViewModel()
+    val state by viewModel.state.collectAsStateWithLifecycle()
 
-        val context = LocalContext.current
-        val uriHandler = LocalUriHandler.current
-        val navigator = LocalNavigator.current
-        val navigatorErrorMapper = LocalNavigatorErrorMapper.current
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+    val navigator = LocalNavigator.current
+    val navigatorErrorMapper = LocalNavigatorErrorMapper.current
 
-        val lazyStaggeredGridState = rememberLazyStaggeredGridState()
+    val lazyStaggeredGridState = rememberLazyStaggeredGridState()
 
-        ObserveAsEvent(viewModel.actions) { action ->
-            when (action) {
-                is NavigateToDetails -> showDetails(
-                    navigator,
-                    navigatorErrorMapper,
-                    action.authorImageUrl,
-                    action.repoFullName,
-                    context,
-                )
-                is RepoListAction.OpenProfile -> openProfile(action.profileUrl, uriHandler, context)
-                RepoListAction.ScrollToTop -> lazyStaggeredGridState.animateScrollToItem(0)
-                is RepoListAction.ShowMessage -> Toast.makeText(context, action.message, Toast.LENGTH_SHORT).show()
-            }
-        }
-
-        CompositionLocalProvider(
-            LocalAnimatedContentScope provides this,
-        ) {
-            RepoList(
-                state = state,
-                lazyStaggeredGridState = lazyStaggeredGridState,
-                onEvent = viewModel::onEvent,
+    ObserveAsEvent(viewModel.actions) { action ->
+        when (action) {
+            is NavigateToDetails -> showDetails(
+                navigator,
+                navigatorErrorMapper,
+                action.authorImageUrl,
+                action.repoFullName,
+                context,
             )
+            is RepoListAction.OpenProfile -> openProfile(action.profileUrl, uriHandler, context)
+            RepoListAction.ScrollToTop -> lazyStaggeredGridState.animateScrollToItem(0)
+            is RepoListAction.ShowMessage -> Toast.makeText(context, action.message, Toast.LENGTH_SHORT).show()
         }
     }
+
+    RepoList(
+        state = state,
+        lazyStaggeredGridState = lazyStaggeredGridState,
+        onEvent = viewModel::onEvent,
+    )
 }
 
-private fun NavGraphBuilder.repoDetail() {
-    composable<Destination.RepoDetail>(
-        enterTransition = {
-            slideInHorizontally(
-                animationSpec = tween(durationMillis = NAVIGATION_ANIMATION_DURATION),
-                initialOffsetX = { fullWidth -> fullWidth },
-            ) + fadeIn(animationSpec = tween(durationMillis = NAVIGATION_ANIMATION_DURATION))
-        },
-        popExitTransition = {
-            slideOutHorizontally(
-                animationSpec = tween(durationMillis = NAVIGATION_ANIMATION_DURATION),
-                targetOffsetX = { fullWidth -> fullWidth },
-            ) + fadeOut(animationSpec = tween(durationMillis = NAVIGATION_ANIMATION_DURATION))
-        },
-    ) {
-        val viewModel: RepoDetailViewModel = hiltViewModel()
-        val state by viewModel.state.collectAsStateWithLifecycle()
+@Composable
+private fun RepoDetailEntry(key: Destination.RepoDetail) {
+    val viewModel = hiltViewModel<RepoDetailViewModel, RepoDetailViewModel.Factory>(
+        creationCallback = { factory -> factory.create(key) },
+    )
+    val state by viewModel.state.collectAsStateWithLifecycle()
 
-        val context = LocalContext.current
+    val context = LocalContext.current
 
-        ObserveAsEvent(viewModel.actions) { action ->
-            when (action) {
-                is RepoDetailAction.ShowMessage ->
-                    Toast.makeText(context, action.message, Toast.LENGTH_SHORT).show()
-            }
-        }
-
-        CompositionLocalProvider(
-            LocalAnimatedContentScope provides this,
-        ) {
-            RepoDetail(
-                state = state,
-                onEvent = viewModel::onEvent,
-            )
+    ObserveAsEvent(viewModel.actions) { action ->
+        when (action) {
+            is RepoDetailAction.ShowMessage ->
+                Toast.makeText(context, action.message, Toast.LENGTH_SHORT).show()
         }
     }
+
+    RepoDetail(
+        state = state,
+        onEvent = viewModel::onEvent,
+    )
 }
 
 private suspend fun showDetails(
@@ -201,4 +188,22 @@ fun openProfile(profileUrl: String, uriHandler: UriHandler, context: Context) {
     }
 }
 
-private const val NAVIGATION_ANIMATION_DURATION = 300
+private fun slideTransition(
+    enterFromLeft: Boolean,
+    durationMillis: Int = NAVIGATION_ANIMATION_DURATION_MILLIS,
+): ContentTransform {
+    val direction = if (enterFromLeft) -1 else 1
+    return (
+        slideInHorizontally(
+            animationSpec = tween(durationMillis = durationMillis),
+            initialOffsetX = { fullWidth -> direction * fullWidth },
+        ) + fadeIn(animationSpec = tween(durationMillis = durationMillis))
+    ) togetherWith (
+        slideOutHorizontally(
+            animationSpec = tween(durationMillis = durationMillis),
+            targetOffsetX = { fullWidth -> -direction * fullWidth },
+        ) + fadeOut(animationSpec = tween(durationMillis = durationMillis))
+    )
+}
+
+private const val NAVIGATION_ANIMATION_DURATION_MILLIS = 300

--- a/core-ui/build.gradle.kts
+++ b/core-ui/build.gradle.kts
@@ -17,6 +17,9 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.coil.network)
 
+    api(libs.navigation3.runtime)
+    api(libs.navigation3.ui)
+
     implementation(libs.kotlinx.serialization)
     implementation(libs.lifecycle.viewmodel)
 }

--- a/core-ui/src/main/java/com/matijasokol/coreui/components/SharedElement.kt
+++ b/core-ui/src/main/java/com/matijasokol/coreui/components/SharedElement.kt
@@ -2,13 +2,12 @@
 
 package com.matijasokol.coreui.components
 
-import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.Modifier
+import androidx.navigation3.ui.LocalNavAnimatedContentScope
 
-val LocalAnimatedContentScope = compositionLocalOf<AnimatedContentScope> { error("AnimatedContentScope not provided") }
 val LocalSharedTransitionScope =
     compositionLocalOf<SharedTransitionScope> { error("SharedTransitionScope not provided") }
 
@@ -17,7 +16,7 @@ fun Modifier.withSharedElement(
     key: Any,
 ): Modifier {
     val sharedTransitionScope = LocalSharedTransitionScope.current
-    val animatedContentScope = LocalAnimatedContentScope.current
+    val animatedContentScope = LocalNavAnimatedContentScope.current
 
     return with(sharedTransitionScope) {
         sharedElement(
@@ -32,7 +31,7 @@ fun Modifier.withSharedBounds(
     key: Any,
 ): Modifier {
     val sharedTransitionScope = LocalSharedTransitionScope.current
-    val animatedContentScope = LocalAnimatedContentScope.current
+    val animatedContentScope = LocalNavAnimatedContentScope.current
 
     return with(sharedTransitionScope) {
         sharedBounds(

--- a/core-ui/src/main/java/com/matijasokol/coreui/navigation/Destination.kt
+++ b/core-ui/src/main/java/com/matijasokol/coreui/navigation/Destination.kt
@@ -1,8 +1,9 @@
 package com.matijasokol.coreui.navigation
 
+import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
 
-sealed interface Destination {
+sealed interface Destination : NavKey {
 
     @Serializable
     data object RepoList : Destination

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,8 @@ turbine = "1.2.1"
 
 composeBom = "2026.03.01"
 composeNavigationHilt = "1.3.0"
-composeNavigation = "2.9.7"
+navigation3 = "1.1.1"
+navigation3Lifecycle = "2.10.0"
 coil = "3.4.0"
 material3 = "1.4.0"
 splash = "1.2.0"
@@ -70,8 +71,10 @@ compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-mani
 compose-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 compose-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 
+navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3" }
+navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3" }
 compose-hilt-navigation = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "composeNavigationHilt" }
-compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "composeNavigation" }
+lifecycle-viewmodel-navigation3 = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-navigation3", version.ref = "navigation3Lifecycle" }
 
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }

--- a/repo/detail/build.gradle.kts
+++ b/repo/detail/build.gradle.kts
@@ -20,7 +20,6 @@ dependencies {
     implementation(projects.coreUi)
     implementation(projects.repo.domain)
 
-    implementation(libs.compose.navigation)
     implementation(libs.activity.compose)
 
     implementation(libs.kotlinx.collections)

--- a/repo/detail/src/androidTest/java/com/matijasokol/repo/detail/ui/RepoDetailTest.kt
+++ b/repo/detail/src/androidTest/java/com/matijasokol/repo/detail/ui/RepoDetailTest.kt
@@ -9,8 +9,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import androidx.test.core.app.ApplicationProvider
-import com.matijasokol.coreui.components.LocalAnimatedContentScope
 import com.matijasokol.coreui.components.LocalSharedTransitionScope
 import com.matijasokol.coreui.dictionary.DictionaryImpl
 import com.matijasokol.repo.datasourcetest.network.serializeRepoResponseData
@@ -40,7 +40,7 @@ class RepoDetailTest {
             SharedTransitionLayout {
                 CompositionLocalProvider(
                     LocalSharedTransitionScope provides this,
-                    LocalAnimatedContentScope provides this@AnimatedContent,
+                    LocalNavAnimatedContentScope provides this@AnimatedContent,
                 ) {
                     content()
                 }

--- a/repo/detail/src/main/java/com/matijasokol/repo/detail/RepoDetailViewModel.kt
+++ b/repo/detail/src/main/java/com/matijasokol/repo/detail/RepoDetailViewModel.kt
@@ -1,13 +1,14 @@
 package com.matijasokol.repo.detail
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.toRoute
 import com.matijasokol.core.dictionary.Dictionary
 import com.matijasokol.coreui.navigation.Destination
 import com.matijasokol.coreui.viewmodel.stateIn
 import com.matijasokol.repo.domain.usecase.GetRepoDetailsUseCase
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
@@ -19,15 +20,19 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class RepoDetailViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle,
+@HiltViewModel(assistedFactory = RepoDetailViewModel.Factory::class)
+class RepoDetailViewModel @AssistedInject constructor(
+    @Assisted private val destination: Destination.RepoDetail,
     getRepoDetails: GetRepoDetailsUseCase,
     uiMapper: RepoDetailsUiMapper,
     private val dictionary: Dictionary,
 ) : ViewModel() {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(destination: Destination.RepoDetail): RepoDetailViewModel
+    }
 
     private val _actions = Channel<RepoDetailAction>(capacity = BUFFERED)
     val actions = _actions.receiveAsFlow()
@@ -35,23 +40,21 @@ class RepoDetailViewModel @Inject constructor(
     private val fetchTrigger = Channel<Unit>()
     private val isLoading = MutableStateFlow(true)
 
-    private val params = savedStateHandle.toRoute<Destination.RepoDetail>()
-
     private val repo = fetchTrigger.receiveAsFlow()
         .onStart { emit(Unit) }
         .onEach { isLoading.update { true } }
-        .map { getRepoDetails(params.repoFullName) }
+        .map { getRepoDetails(destination.repoFullName) }
         .onEach { isLoading.update { false } }
 
     val state = combine(
         isLoading,
         repo,
     ) { loading, repo ->
-        uiMapper.toUiState(loading, repo, params.repoFullName, params.authorImageUrl)
+        uiMapper.toUiState(loading, repo, destination.repoFullName, destination.authorImageUrl)
     }.stateIn(
         initialValue = RepoDetailState.Loading(
-            repoFullName = params.repoFullName,
-            authorImageUrl = params.authorImageUrl,
+            repoFullName = destination.repoFullName,
+            authorImageUrl = destination.authorImageUrl,
         ),
     )
 

--- a/repo/detail/src/test/java/com/matijasokol/repo/detail/RepoDetailViewModelTest.kt
+++ b/repo/detail/src/test/java/com/matijasokol/repo/detail/RepoDetailViewModelTest.kt
@@ -1,37 +1,21 @@
 package com.matijasokol.repo.detail
 
-import androidx.lifecycle.SavedStateHandle
-import androidx.navigation.toRoute
 import app.cash.turbine.test
 import com.matijasokol.coreui.navigation.Destination
 import com.matijasokol.repo.datasourcetest.network.RepoServiceFake
 import com.matijasokol.repo.datasourcetest.network.RepoServiceResponseType
 import com.matijasokol.repo.domain.usecase.GetRepoDetailsUseCase
 import com.matijasokol.test.FakeDictionary
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be instance of`
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(AndroidCoroutinesExtension::class)
 class RepoDetailViewModelTest {
 
-    private val savedStateHandle = mockk<SavedStateHandle>()
+    private val destination = Destination.RepoDetail(repoFullName = "JetBrains/kotlin", authorImageUrl = "")
     private val uiMapper = RepoDetailsUiMapper(FakeDictionary())
-
-    @BeforeEach
-    fun before() {
-        mockkStatic("androidx.navigation.SavedStateHandleKt")
-        every {
-            savedStateHandle.toRoute<Destination.RepoDetail>()
-        } returns Destination.RepoDetail(repoFullName = "JetBrains/kotlin", authorImageUrl = "")
-    }
 
     @Test
     fun `should RETURN SUCCESS STATE when request was successful`() = runTest {
@@ -42,7 +26,7 @@ class RepoDetailViewModelTest {
         )
 
         val sut = RepoDetailViewModel(
-            savedStateHandle = savedStateHandle,
+            destination = destination,
             getRepoDetails = getRepoDetailsUseCase,
             uiMapper = uiMapper,
             dictionary = FakeDictionary(),
@@ -63,7 +47,7 @@ class RepoDetailViewModelTest {
         )
 
         val sut = RepoDetailViewModel(
-            savedStateHandle = savedStateHandle,
+            destination = destination,
             getRepoDetails = getRepoDetailsUseCase,
             uiMapper = uiMapper,
             dictionary = FakeDictionary(),
@@ -73,10 +57,5 @@ class RepoDetailViewModelTest {
             awaitItem() `should be instance of` RepoDetailState.Loading::class
             awaitItem() `should be instance of` RepoDetailState.Error::class
         }
-    }
-
-    @AfterEach
-    fun after() {
-        unmockkStatic("androidx.navigation.SavedStateHandleKt")
     }
 }

--- a/repo/list/src/androidTest/java/com/matijasokol/repo/list/ui/RepoListTest.kt
+++ b/repo/list/src/androidTest/java/com/matijasokol/repo/list/ui/RepoListTest.kt
@@ -9,8 +9,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import androidx.test.core.app.ApplicationProvider
-import com.matijasokol.coreui.components.LocalAnimatedContentScope
 import com.matijasokol.coreui.components.LocalSharedTransitionScope
 import com.matijasokol.coreui.dictionary.DictionaryImpl
 import com.matijasokol.repo.datasourcetest.network.serializeRepoResponseData
@@ -43,7 +43,7 @@ class RepoListTest {
             SharedTransitionLayout {
                 CompositionLocalProvider(
                     LocalSharedTransitionScope provides this,
-                    LocalAnimatedContentScope provides this@AnimatedContent,
+                    LocalNavAnimatedContentScope provides this@AnimatedContent,
                 ) {
                     content()
                 }


### PR DESCRIPTION
## Summary
- Migrated from Jetpack Navigation 2 to Navigation 3
- Updated Target SDK to 36
## Changes
- Replaced Navigation 2 components with Navigation 3 APIs (`NavDisplay`, `rememberNavBackStack`, `entryProvider`, etc.)
- Updated shared transition and animated content scope handling for Navigation 3
- Added `predictivePopTransitionSpec` to `NavDisplay` for consistent predictive back gesture animations
- Updated `targetSdk` to 36
- Updated related dependencies
Closes #125
Closes #158