### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/template.md
+++ b/.github/ISSUE_TEMPLATE/template.md
@@ -1,0 +1,51 @@
+---
+name: Feature / Task
+about: Standard issue template for features, tasks, or improvements
+title: ''
+labels: ''
+assignees: ''
+---
+
+## Goal
+
+Briefly describe what this issue should achieve.
+
+## Scope
+
+### In Scope
+
+-
+
+### Out of Scope
+
+-
+
+## Implementation Guidelines
+
+### Architecture / Structure
+
+- Optional
+
+### Data Flow
+
+- Optional
+
+### State Management
+
+- Optional
+
+### Edge Cases
+
+- Optional
+
+### Constraints / Avoid
+
+- Optional
+
+## Deliverables
+
+- Optional
+
+## Notes for the Team
+
+- Optional

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Closes issue
+
+Closes #<issue number>
+
+## Design
+
+- Figma Link (optional)
+
+## Changes
+
+### Proposed solution
+
+- Proposed solution for a bugfix, or a more in depth summary of a feature
+
+## Testing
+
+- [ ] Added a test for the main behavior change
+- [ ] Existing tests cover this change
+- [ ] No test needed (explain why):
+
+## Demo screenshots
+
+<img src="" width=25%>
+<video>{height=600px}


### PR DESCRIPTION
## Summary
Adds GitHub issue and pull request templates.

## Notes
- Adds a standard issue template for features, tasks, and improvements.
- Adds a pull request template with sections for linked issues, design, changes, testing, and demo screenshots.