### PR TITLE
Update docs with latest libs versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ This file provides instructions and context for AI coding agents working on the 
 GitHubApp is an Android application for browsing GitHub repositories, built with Kotlin and Jetpack Compose following clean architecture and multi-module design principles.
 
 - **Package name:** `com.matijasokol.githubapp`
-- **Min SDK:** 24 | **Target/Compile SDK:** 36
-- **Kotlin:** 2.3 | **AGP:** 9.2
+- **Min SDK:** 24 | **Target/Compile SDK:** 37
+- **Kotlin:** 2.4.10 | **AGP:** 9.3.1
 - **Product flavors:** `free`, `paid`
 
 ## Architecture
@@ -41,7 +41,7 @@ app/                     → Application module (entry point, DI setup, navigati
 
 | Layer           | Technology |
 |-----------------|---|
-| Language        | Kotlin 2.3 with Coroutines + Flow |
+| Language        | Kotlin 2.4.10 with Coroutines + Flow |
 | UI              | Jetpack Compose with Material |
 | Navigation      | Navigation 3 with Shared Element Transitions |
 | Networking      | Ktor + Kotlinx Serialization |

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Feature screens follow an MVI-style structure:
 
 - Android Studio with JDK 21 configured.
 - Minimum supported Android version: API 24.
-- Target SDK: API 36.
+- Compile SDK: API 37.
+- Target SDK: API 37.
 
 The Gradle wrapper is checked in, so local builds should use `./gradlew`.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-compileSdk = "36"
+compileSdk = "37"
 minSdk = "24"
-targetSdk = "36"
+targetSdk = "37"
 
 kotlin = "2.4.10"
 ksp = "2.3.9"
@@ -11,9 +11,9 @@ kotlinxCollections = "0.5.1"
 
 activityCompose = "1.13.0"
 agp = "9.3.1"
-coreKtx = "1.18.0" # newer versions require targetSdk 37
+coreKtx = "1.19.0"
 appcompat = "1.7.1"
-lifecycleViewModel = "2.10.0" # newer versions require targetSdk 37
+lifecycleViewModel = "2.11.0"
 
 testRunner = "1.7.0"
 junitBom = "6.1.2"
@@ -22,9 +22,9 @@ kluent = "1.73"
 turbine = "1.2.1"
 
 composeBom = "2026.06.01"
-composeNavigationHilt = "1.3.0" # newer versions require targetSdk 37
+composeNavigationHilt = "1.4.0"
 navigation3 = "1.1.4"
-navigation3Lifecycle = "2.10.0" # newer versions require targetSdk 37
+navigation3Lifecycle = "2.11.0"
 coil = "3.5.0"
 material3 = "1.4.0"
 splash = "1.2.0"


### PR DESCRIPTION
## Closes issue

Closes #187

## Changes

### Proposed solution

- Updates compile and target SDK to API 37.
- Updates AndroidX dependencies that required `targetSdk 37`.
- Updates project documentation to reflect the latest SDK, Kotlin, and AGP versions.

## Testing

- [ ] Added a test for the main behavior change
- [ ] Existing tests cover this change
- [x] No test needed (dependency and documentation updates only)