### PR TITLE
Add Konsist

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -97,3 +97,4 @@ jobs:
           ./gradlew repo:domain:test --stacktrace
           ./gradlew repo:detail:test --stacktrace
           ./gradlew repo:list:test --stacktrace
+          ./gradlew konsist:test --stacktrace

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /.idea/assetWizardSettings.xml
 .idea
 .DS_Store
-/build
+build/
 /captures
 .externalNativeBuild
 .cxx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ app/                     → Application module (entry point, DI setup, navigati
 │   ├── datasource-test/ → Test doubles for the data layer
 │   ├── list/            → Repository list screen (UI + ViewModel)
 │   └── detail/          → Repository detail screen (UI + ViewModel)
+├── konsist/             → Project-wide architecture and naming rules (Konsist tests)
 ├── test/                → Shared test fixtures
 └── build-logic/         → Gradle convention plugins
 ```
@@ -50,8 +51,8 @@ app/                     → Application module (entry point, DI setup, navigati
 | Image Loading   | Coil 3 |
 | DI              | Hilt |
 | Error Handling  | Arrow |
-| Static Analysis | Ktlint + Detekt |
 | Testing         | JUnit 6, MockK, Turbine, Kluent |
+| Quality         | Ktlint, Detekt, Konsist architecture tests |
 | Build           | Gradle convention plugins + Version Catalog (`gradle/libs.versions.toml`) |
 
 ## Code Conventions
@@ -110,6 +111,7 @@ Each feature screen follows a strict **MVI** (Model-View-Intent) pattern:
 - Use **fakes** (preferred over mocks) for data layer tests (`RepoServiceFake`, `FakePaginator`).
 - Coroutine tests use `runTest` with a custom `AndroidCoroutinesExtension` (JUnit 6 extension).
 - Compose UI tests use `compose-junit4` with test tags defined in `**/test/TestTags.kt`.
+- Konsist architecture tests live in `konsist/src/test/kotlin/com/matijasokol/githubapp/konsist` and run with `./gradlew konsist:test`. They enforce package boundaries, MVI/ViewModel conventions, immutable UI state collections, DTO naming/serialization, Compose placement, and related project structure rules.
 - Test file naming: `<ClassUnderTest>Test.kt`.
 - Test method naming: backtick-style descriptive names (e.g., `` `should RETURN SUCCESS STATE when request was successful`() ``).
 
@@ -124,7 +126,7 @@ Each feature screen follows a strict **MVI** (Model-View-Intent) pattern:
 - ✅ Use `ImmutableList` for list properties in state classes.
 - ✅ Write unit tests for ViewModels and use cases.
 - ✅ Use `combine` to derive state from multiple flows.
-- ✅ Run `./gradlew detekt` and `./gradlew ktlintCheck` before submitting changes.
+- ✅ Run `./gradlew konsist:test`, `./gradlew detekt`, and `./gradlew ktlintCheck` before submitting changes.
 
 ### Don't
 
@@ -148,6 +150,9 @@ Each feature screen follows a strict **MVI** (Model-View-Intent) pattern:
 
 # Run unit tests
 ./gradlew test
+
+# Run Konsist architecture and naming tests
+./gradlew konsist:test
 
 # Run detekt static analysis
 ./gradlew detekt

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ repo/
   datasource-test/       Fakes and JSON fixtures for tests
   list/                  Repository list screen, ViewModel, UI tests
   detail/                Repository detail screen, ViewModel, UI tests
+konsist/                 Project-wide Konsist architecture and naming tests
 test/                    Shared test fixtures
 build-logic/             Gradle convention plugins, quality setup, versioning tasks
 ```
@@ -93,7 +94,7 @@ Feature screens follow an MVI-style structure:
 | Dependency injection | Hilt                                                         |
 | Error handling | Arrow                                                        |
 | Testing | JUnit, MockK, Turbine, Kluent, Compose UI tests              |
-| Quality | Ktlint, Detekt, Compose Detekt rules                         |
+| Quality | Ktlint, Detekt, Compose Detekt rules, Konsist architecture tests |
 | Build | AGP, Gradle, convention plugins, version catalog, Kotlin DSL |
 
 ## Requirements
@@ -154,7 +155,10 @@ Common Gradle commands:
 ./gradlew test
 
 # Run app and feature unit tests explicitly
-./gradlew app:test repo:domain:test repo:list:test repo:detail:test
+./gradlew app:test repo:domain:test repo:list:test repo:detail:test konsist:test
+
+# Run Konsist architecture tests
+./gradlew konsist:test
 
 # Static analysis and formatting checks
 ./gradlew ktlintCheck detekt
@@ -214,7 +218,7 @@ The PR check workflow has four jobs:
 - `static_analysis` runs `./gradlew ktlintCheck detekt --stacktrace`.
 - `build_free` runs `./gradlew assembleProdFreeRelease --stacktrace`.
 - `build_paid` runs `./gradlew assembleProdPaidRelease --stacktrace`.
-- `unit_tests` runs unit tests for `app`, `repo:domain`, `repo:detail`, and `repo:list`.
+- `unit_tests` runs unit tests for `app`, `repo:domain`, `repo:detail`, `repo:list`, and Konsist architecture tests.
 
 Release artifact workflows require the signing secrets used by Gradle:
 
@@ -232,6 +236,17 @@ open pull requests per ecosystem.
 - UI strings should go through resources. Use `stringResource` in composables and the `Dictionary` abstraction where
   strings are needed in ViewModels or mappers.
 - Domain modules should remain pure Kotlin/JVM and free of Android, datasource, and UI dependencies.
+
+## Konsist Architecture Checks
+
+Konsist architecture tests live in `konsist/src/test/kotlin/com/matijasokol/githubapp/konsist` and inspect production sources with
+`Konsist.scopeFromProduction()`. The current rules cover package layer dependencies, domain and datasource boundaries,
+package naming and path matching, use case and ViewModel conventions, MVI companion declarations, UI model immutable
+collections, datasource DTO naming/serialization, Compose placement, data class immutability, and wildcard imports.
+
+When adding or changing a rule, prefer a focused test class and avoid checks that duplicate ktlint or detekt unless
+Konsist adds project-specific value. Run `./gradlew konsist:test` locally, or `./gradlew test` to include Konsist with
+the rest of the unit test lifecycle.
 
 ## Download
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ junitBom = "6.1.2"
 mockk = "1.14.11"
 kluent = "1.73"
 turbine = "1.2.1"
+konsist = "0.17.3"
 
 composeBom = "2026.06.01"
 composeNavigationHilt = "1.4.0"
@@ -54,6 +55,7 @@ junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 kluent = { group = "org.amshove.kluent", name = "kluent", version.ref = "kluent" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
+konsist = { group = "com.lemonappdev", name = "konsist", version.ref = "konsist" }
 
 kotlin-metadata-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-metadata-jvm", version.ref = "kotlin" }
 kotlinx-serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }

--- a/konsist/build.gradle.kts
+++ b/konsist/build.gradle.kts
@@ -1,0 +1,19 @@
+import org.gradle.api.tasks.testing.Test
+
+plugins {
+    alias(libs.plugins.githubapp.jvm.library)
+}
+
+dependencies {
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.kluent)
+    testImplementation(libs.konsist)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+tasks.withType<Test>().configureEach {
+    // These tests inspect production sources across modules, which Gradle would not otherwise track as this module's inputs.
+    outputs.upToDateWhen { false }
+}

--- a/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/ArchitectureKonsistTest.kt
+++ b/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/ArchitectureKonsistTest.kt
@@ -1,0 +1,98 @@
+package com.matijasokol.githubapp.konsist
+
+import com.lemonappdev.konsist.api.architecture.KoArchitectureCreator.assertArchitecture
+import com.lemonappdev.konsist.api.architecture.Layer
+import com.lemonappdev.konsist.api.verify.assertFalse
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.jupiter.api.Test
+
+class ArchitectureKonsistTest {
+
+    @Test
+    fun `package layers have correct dependencies`() {
+        productionScope.assertArchitecture {
+            val core = Layer("Core", "com.matijasokol.core..")
+            val coreUi = Layer("Core UI", "com.matijasokol.coreui..")
+            val domain = Layer("Repo Domain", "com.matijasokol.repo.domain..")
+            val datasource = Layer("Repo Datasource", "com.matijasokol.repo.datasource..")
+            val list = Layer("Repo List", "com.matijasokol.repo.list..")
+            val detail = Layer("Repo Detail", "com.matijasokol.repo.detail..")
+            val app = Layer("App", "com.matijasokol.githubapp..")
+
+            core.dependsOnNothing()
+            coreUi.dependsOn(core)
+            domain.dependsOn(core)
+            datasource.dependsOn(core, domain)
+            list.dependsOn(core, coreUi, domain)
+            detail.dependsOn(core, coreUi, domain)
+            app.dependsOn(core, coreUi, domain, datasource, list, detail)
+        }
+    }
+
+    @Test
+    fun `domain module does not depend on Android datasource or UI packages`() {
+        productionScope
+            .files
+            .filter { it.path.normalizedPath().contains("/repo/domain/src/main/") }
+            .assertFalse { file ->
+                file.imports.any { import ->
+                    forbiddenDomainImports.any { forbiddenImport ->
+                        import.name.startsWith("$forbiddenImport.")
+                    }
+                }
+            }
+    }
+
+    @Test
+    fun `compose functions live only in UI modules`() {
+        productionScope
+            .functions()
+            .filter { it.hasAnnotationWithName("Composable") }
+            .assertTrue { function ->
+                composeModulePathSegments.any { pathSegment ->
+                    function.path.normalizedPath().contains(pathSegment)
+                }
+            }
+    }
+
+    @Test
+    fun `wildcard imports are not used`() {
+        productionScope
+            .imports
+            .assertFalse { it.isWildcard }
+    }
+
+    @Test
+    fun `package names are lowercase`() {
+        productionScope
+            .packages
+            .assertTrue { it.name.matches(LOWERCASE_PACKAGE_REGEX) }
+    }
+
+    @Test
+    fun `package declarations match file paths`() {
+        productionScope
+            .packages
+            .assertTrue { it.hasMatchingPath }
+    }
+}
+
+private val forbiddenDomainImports = listOf(
+    "android",
+    "androidx",
+    "com.matijasokol.coreui",
+    "com.matijasokol.githubapp",
+    "com.matijasokol.repo.datasource",
+    "com.matijasokol.repo.datasourcetest",
+    "com.matijasokol.repo.detail",
+    "com.matijasokol.repo.list",
+)
+
+private val composeModulePathSegments = listOf(
+    "/app/src/",
+    "/core-ui/src/",
+    "/repo/list/src/",
+    "/repo/detail/src/",
+)
+
+private val LOWERCASE_PACKAGE_REGEX = "^[a-z.]+$".toRegex()

--- a/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/DatasourceKonsistTest.kt
+++ b/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/DatasourceKonsistTest.kt
@@ -1,0 +1,51 @@
+package com.matijasokol.githubapp.konsist
+
+import com.lemonappdev.konsist.api.verify.assertFalse
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.jupiter.api.Test
+
+class DatasourceKonsistTest {
+
+    @Test
+    fun `datasource implementations implement matching domain contracts`() {
+        datasourceClasses()
+            .filter { datasourceContractImplementations.containsKey(it.name) }
+            .assertTrue { implementation ->
+                implementation.hasParent { parent ->
+                    parent.name == datasourceContractImplementations.getValue(implementation.name)
+                }
+            }
+    }
+
+    @Test
+    fun `datasource classes do not import UI packages`() {
+        datasourceFiles()
+            .assertFalse { file ->
+                file.imports.any { import ->
+                    forbiddenDatasourceImports.any { forbiddenImport ->
+                        import.name.startsWith("$forbiddenImport.")
+                    }
+                }
+            }
+    }
+
+    @Test
+    fun `datasource DTOs use Dto suffix and Serializable annotation`() {
+        datasourceClasses()
+            .filter { it.resideInPackage("..network.model") }
+            .assertTrue { dto ->
+                dto.name.endsWith("Dto") && dto.hasAnnotationWithName("Serializable")
+            }
+    }
+}
+
+private val datasourceContractImplementations = mapOf(
+    "RepoCacheImpl" to "RepoCache",
+    "RepoServiceImpl" to "RepoService",
+)
+
+private val forbiddenDatasourceImports = listOf(
+    "com.matijasokol.coreui",
+    "com.matijasokol.repo.list",
+    "com.matijasokol.repo.detail",
+)

--- a/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/KonsistScopes.kt
+++ b/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/KonsistScopes.kt
@@ -1,0 +1,36 @@
+package com.matijasokol.githubapp.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoFileDeclaration
+import com.lemonappdev.konsist.api.declaration.KoInterfaceDeclaration
+
+internal val productionScope = Konsist.scopeFromProduction()
+
+internal fun productionClasses(): List<KoClassDeclaration> = productionScope
+    .classes(includeNested = false, includeLocal = false)
+
+internal fun productionInterfaces(): List<KoInterfaceDeclaration> = productionScope
+    .interfaces(includeNested = false)
+
+internal fun viewModelClasses(): List<KoClassDeclaration> = productionClasses()
+    .filter { clazz ->
+        clazz.hasParent { parent -> parent.name == "ViewModel" } &&
+            clazz.containingFile.hasImportWithName(ANDROIDX_VIEW_MODEL_IMPORT)
+    }
+
+internal fun useCaseClasses(): List<KoClassDeclaration> = productionClasses()
+    .filter { it.path.normalizedPath().contains(DOMAIN_USECASE_PATH) }
+
+internal fun datasourceFiles(): List<KoFileDeclaration> = productionScope
+    .files
+    .filter { it.path.normalizedPath().contains(DATASOURCE_MAIN_PATH) }
+
+internal fun datasourceClasses(): List<KoClassDeclaration> = productionClasses()
+    .filter { it.path.normalizedPath().contains(DATASOURCE_MAIN_PATH) }
+
+internal fun String.normalizedPath(): String = replace('\\', '/')
+
+private const val DATASOURCE_MAIN_PATH = "/repo/datasource/src/main/"
+private const val DOMAIN_USECASE_PATH = "/repo/domain/src/main/java/com/matijasokol/repo/domain/usecase/"
+private const val ANDROIDX_VIEW_MODEL_IMPORT = "androidx.lifecycle.ViewModel"

--- a/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/MviKonsistTest.kt
+++ b/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/MviKonsistTest.kt
@@ -1,0 +1,42 @@
+package com.matijasokol.githubapp.konsist
+
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+
+class MviKonsistTest {
+
+    @Test
+    fun `feature packages with view models declare MVI companions`() {
+        featurePackagesWithViewModels().forEach { packageName ->
+            val packageFiles = productionScope.files.filter { it.packagee?.name == packageName }
+
+            packageFiles
+                .any { file ->
+                    file.hasClassOrInterface(
+                        includeNested = false,
+                        includeLocal = false,
+                    ) { it.name.endsWith("State") }
+                }.shouldBeTrue()
+
+            packageFiles
+                .any { file ->
+                    file.hasClassOrInterface(includeNested = false) { it.name.endsWith("Event") }
+                }.shouldBeTrue()
+
+            packageFiles
+                .any { file ->
+                    file.hasClassOrInterface(includeNested = false) { it.name.endsWith("Action") }
+                }.shouldBeTrue()
+
+            packageFiles
+                .any { file ->
+                    file.hasClass(includeNested = false, includeLocal = false) { it.name.endsWith("UiMapper") }
+                }.shouldBeTrue()
+        }
+    }
+
+    private fun featurePackagesWithViewModels(): List<String> = viewModelClasses()
+        .filter { it.resideInPackage("com.matijasokol.repo..") }
+        .mapNotNull { it.packagee?.name }
+        .distinct()
+}

--- a/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/NamingKonsistTest.kt
+++ b/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/NamingKonsistTest.kt
@@ -1,0 +1,71 @@
+package com.matijasokol.githubapp.konsist
+
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.jupiter.api.Test
+
+class NamingKonsistTest {
+
+    @Test
+    fun `use cases use UseCase suffix and expose operator invoke`() {
+        useCaseClasses()
+            .assertTrue { useCase ->
+                useCase.name.endsWith("UseCase") &&
+                    useCase.hasFunction(includeNested = false, includeLocal = false) { function ->
+                        function.name == "invoke" &&
+                            function.hasPublicOrDefaultModifier &&
+                            function.hasOperatorModifier
+                    } &&
+                    useCase.countFunctions(includeNested = false, includeLocal = false) { function ->
+                        function.hasPublicOrDefaultModifier
+                    } == 1
+            }
+    }
+
+    @Test
+    fun `view models use ViewModel suffix and Hilt annotation`() {
+        viewModelClasses()
+            .assertTrue { viewModel ->
+                viewModel.name.endsWith("ViewModel") && viewModel.hasAnnotationWithName("HiltViewModel")
+            }
+    }
+
+    @Test
+    fun `view models have a single constructor`() {
+        viewModelClasses()
+            .assertTrue { viewModel -> viewModel.constructors.size == 1 }
+    }
+
+    @Test
+    fun `view models do not depend on navigator`() {
+        viewModelClasses()
+            .assertTrue { viewModel ->
+                viewModel.hasAllProperties(includeNested = false) { property ->
+                    property.type?.name != "Navigator"
+                }
+            }
+    }
+
+    @Test
+    fun `events and actions are sealed interfaces or classes`() {
+        listOf(productionClasses(), productionInterfaces())
+            .flatten()
+            .filter { it.name.endsWith("Event") || it.name.endsWith("Action") }
+            .assertTrue { it.hasSealedModifier }
+    }
+
+    @Test
+    fun `state declarations are data classes or sealed state hierarchies`() {
+        productionClasses()
+            .filter { it.name.endsWith("State") }
+            .assertTrue { state -> state.hasDataModifier || state.hasSealedModifier }
+    }
+
+    @Test
+    fun `data classes use only val properties`() {
+        productionClasses()
+            .filter { it.hasDataModifier }
+            .assertTrue { dataClass ->
+                dataClass.hasAllProperties(includeNested = false) { property -> property.isVal }
+            }
+    }
+}

--- a/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/PresentationKonsistTest.kt
+++ b/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/PresentationKonsistTest.kt
@@ -1,0 +1,61 @@
+package com.matijasokol.githubapp.konsist
+
+import com.lemonappdev.konsist.api.verify.assertTrue
+import org.junit.jupiter.api.Test
+
+class PresentationKonsistTest {
+
+    @Test
+    fun `state and list UI models use ImmutableList for exposed collections`() {
+        productionClasses()
+            .filter { uiModelPackageNames.any(it::resideInPackage) }
+            .filter { uiModelSuffixes.any(it.name::endsWith) }
+            .flatMap { uiModel -> uiModel.properties(includeNested = false) }
+            .filter { property -> property.text.contains(PLAIN_LIST_TYPE_DECLARATION) }
+            .assertTrue { property -> property.text.contains(IMMUTABLE_LIST_TYPE_DECLARATION) }
+    }
+
+    @Test
+    fun `view models expose StateFlow state`() {
+        viewModelClasses()
+            .flatMap { viewModel -> viewModel.properties(includeNested = false) }
+            .filter { property -> property.name == "state" }
+            .assertTrue { property -> property.text.contains(STATE_FLOW_TYPE_DECLARATION) }
+    }
+
+    @Test
+    fun `view models expose Flow actions`() {
+        viewModelClasses()
+            .flatMap { viewModel -> viewModel.properties(includeNested = false) }
+            .filter { property -> property.name == "actions" }
+            .assertTrue { property -> property.text.contains(FLOW_TYPE_DECLARATION) }
+    }
+
+    @Test
+    fun `view models have onEvent event as only public event entry point`() {
+        viewModelClasses()
+            .assertTrue { viewModel ->
+                viewModel.hasFunction(includeNested = false, includeLocal = false) { function ->
+                    function.name == "onEvent" &&
+                        function.hasPublicOrDefaultModifier &&
+                        function.parameters.size == 1 &&
+                        function.parameters.first().type.name.endsWith("Event")
+                } &&
+                    viewModel.countFunctions(includeNested = false, includeLocal = false) { function ->
+                        function.hasPublicOrDefaultModifier && function.name != "onEvent"
+                    } == 0
+            }
+    }
+}
+
+private val uiModelPackageNames = listOf(
+    "com.matijasokol.repo.list..",
+    "com.matijasokol.repo.detail..",
+)
+
+private val uiModelSuffixes = listOf("State", "Item", "Ui")
+
+private const val PLAIN_LIST_TYPE_DECLARATION = ": List<"
+private const val IMMUTABLE_LIST_TYPE_DECLARATION = ": ImmutableList<"
+private const val STATE_FLOW_TYPE_DECLARATION = ": StateFlow<"
+private const val FLOW_TYPE_DECLARATION = ": Flow<"

--- a/repo/datasource-test/src/main/java/com/matijasokol/repo/datasourcetest/network/Util.kt
+++ b/repo/datasource-test/src/main/java/com/matijasokol/repo/datasourcetest/network/Util.kt
@@ -3,7 +3,7 @@ package com.matijasokol.repo.datasourcetest.network
 import com.matijasokol.repo.datasource.mappers.toAuthor
 import com.matijasokol.repo.datasource.mappers.toRepo
 import com.matijasokol.repo.datasource.network.model.AuthorDto
-import com.matijasokol.repo.datasource.network.model.FetchReposResponse
+import com.matijasokol.repo.datasource.network.model.FetchReposResponseDto
 import com.matijasokol.repo.datasource.network.model.RepoDto
 import com.matijasokol.repo.domain.model.Author
 import com.matijasokol.repo.domain.model.Repo
@@ -13,7 +13,7 @@ private val json = Json {
     ignoreUnknownKeys = true
 }
 
-fun serializeRepoResponseData(jsonData: String): List<Repo> = json.decodeFromString<FetchReposResponse>(
+fun serializeRepoResponseData(jsonData: String): List<Repo> = json.decodeFromString<FetchReposResponseDto>(
     jsonData,
 ).repos.map(RepoDto::toRepo)
 

--- a/repo/datasource/src/main/java/com/matijasokol/repo/datasource/network/RepoServiceImpl.kt
+++ b/repo/datasource/src/main/java/com/matijasokol/repo/datasource/network/RepoServiceImpl.kt
@@ -3,7 +3,7 @@ package com.matijasokol.repo.datasource.network
 import arrow.core.Either
 import com.matijasokol.core.error.NetworkError
 import com.matijasokol.repo.datasource.mappers.toRepo
-import com.matijasokol.repo.datasource.network.model.FetchReposResponse
+import com.matijasokol.repo.datasource.network.model.FetchReposResponseDto
 import com.matijasokol.repo.datasource.network.model.RepoDto
 import com.matijasokol.repo.domain.RepoService
 import com.matijasokol.repo.domain.model.Repo
@@ -29,7 +29,7 @@ class RepoServiceImpl @Inject constructor(private val httpClient: HttpClient) : 
                 parameter(PARAM_PER_PAGE, perPage)
                 parameter(PARAM_PAGE, page)
             }
-        }.body<FetchReposResponse>().repos.map(RepoDto::toRepo)
+        }.body<FetchReposResponseDto>().repos.map(RepoDto::toRepo)
     }
 
     override suspend fun fetchRepoDetails(repoName: String): Either<NetworkError, Repo> = safeNetworkCall {

--- a/repo/datasource/src/main/java/com/matijasokol/repo/datasource/network/model/FetchReposResponseDto.kt
+++ b/repo/datasource/src/main/java/com/matijasokol/repo/datasource/network/model/FetchReposResponseDto.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class FetchReposResponse(
+data class FetchReposResponseDto(
     @SerialName("items")
     val repos: List<RepoDto>,
 )

--- a/repo/detail/src/main/java/com/matijasokol/repo/detail/RepoDetailViewModel.kt
+++ b/repo/detail/src/main/java/com/matijasokol/repo/detail/RepoDetailViewModel.kt
@@ -12,7 +12,9 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -35,7 +37,7 @@ class RepoDetailViewModel @AssistedInject constructor(
     }
 
     private val _actions = Channel<RepoDetailAction>(capacity = BUFFERED)
-    val actions = _actions.receiveAsFlow()
+    val actions: Flow<RepoDetailAction> = _actions.receiveAsFlow()
 
     private val fetchTrigger = Channel<Unit>()
     private val isLoading = MutableStateFlow(true)
@@ -46,7 +48,7 @@ class RepoDetailViewModel @AssistedInject constructor(
         .map { getRepoDetails(destination.repoFullName) }
         .onEach { isLoading.update { false } }
 
-    val state = combine(
+    val state: StateFlow<RepoDetailState> = combine(
         isLoading,
         repo,
     ) { loading, repo ->

--- a/repo/list/src/main/java/com/matijasokol/repo/list/RepoListViewModel.kt
+++ b/repo/list/src/main/java/com/matijasokol/repo/list/RepoListViewModel.kt
@@ -9,7 +9,9 @@ import com.matijasokol.repo.domain.usecase.SortReposUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -28,7 +30,7 @@ class RepoListViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _actions = Channel<RepoListAction>(capacity = BUFFERED)
-    val actions = _actions.receiveAsFlow()
+    val actions: Flow<RepoListAction> = _actions.receiveAsFlow()
 
     private val query = MutableStateFlow(DEFAULT_QUERY)
 
@@ -48,7 +50,7 @@ class RepoListViewModel @Inject constructor(
         sortRepos::invoke,
     )
 
-    val state = combine(
+    val state: StateFlow<RepoListState> = combine(
         paginator.loadState,
         sortedItems,
         query,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,5 +43,6 @@ include(
     "repo:domain",
     "repo:list",
     "repo:detail",
-    "test"
+    "test",
+    "konsist",
 )


### PR DESCRIPTION
## Closes issue

Closes #189

## Changes

### Proposed solution

- Adds a dedicated `konsist` module for project-wide architecture and naming checks.
- Adds Konsist tests for module boundaries, domain isolation, Compose placement, wildcard imports, package naming, datasource contracts, MVI structure, ViewModel conventions, use case conventions, and immutable data classes.
- Wires `konsist:test` into PR checks.
- Documents the new Konsist module, checks, and local commands.

## Testing

- [x] Added a test for the main behavior change
- [ ] Existing tests cover this change
- [ ] No test needed (explain why):