### PR TITLE
Reorganize DI modules by ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ GitHubApp is an Android application for browsing GitHub repositories, built with
 The project follows a **multi-module architecture** with clear separation of concerns:
 
 ```
-app/                     → Application module (entry point, DI setup, navigation)
+app/                     → Application module (entry point, app-level DI setup, navigation)
 ├── core/                → Shared utilities, base classes, error types (pure Kotlin/JVM)
 ├── core-ui/             → Reusable Compose UI components, theming, navigation helpers
 ├── repo/                → Feature: GitHub repositories
@@ -35,7 +35,7 @@ app/                     → Application module (entry point, DI setup, navigati
 - **domain** modules must NOT depend on Android, data, or UI layers.
 - **datasource** depends on **domain** (implements interfaces defined there).
 - **UI/feature** modules (list, detail) depend on **domain** and **core-ui**.
-- **app** module wires everything together with Hilt DI.
+- **app** module owns application-level Hilt setup, Android-specific bindings, and composition decisions, while feature/data modules own DI bindings for implementations they define when the binding fits that module's platform and component scope.
 - Use `projects.*` typesafe accessors for inter-module dependencies (e.g., `projects.repo.domain`).
 
 ## Tech Stack
@@ -93,6 +93,8 @@ Each feature screen follows a strict **MVI** (Model-View-Intent) pattern:
 ### Dependency Injection
 
 - Use Hilt `@Module` / `@Provides` / `@Binds` for wiring.
+- Place DI bindings in the module that owns the implementation when the choice is not app-specific and the target Hilt component is available to that module.
+- Keep bindings in `app` when the application composes or selects between implementations, such as flavor-specific, fake-vs-real, Android application setup, Android context providers, or Android-specific Hilt components.
 - ViewModels use `@HiltViewModel` with `@Inject constructor`.
 - Use cases and mappers use `@Inject constructor` directly (no module needed).
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ forks, or last update date, open author profiles in the browser, and view reposi
 The project uses a multi-module setup with a small application module and feature/domain/data modules under `repo`.
 
 ```text
-app/                     Application entry point, Hilt setup, mode-specific sources, navigation
+app/                     Application entry point, app-level Hilt setup, mode-specific sources, navigation
 core/                    Shared Kotlin utilities, dictionary contract, errors, app mode
 core-ui/                 Shared Compose components, navigation destination types, UI helpers
 repo/
@@ -67,8 +67,10 @@ test/                    Shared test fixtures
 build-logic/             Gradle convention plugins, quality setup, versioning tasks
 ```
 
-Domain modules stay free of Android dependencies. Datasource modules implement domain contracts. UI modules depend
-on domain and shared UI helpers. Application wiring happens in `app`.
+Domain modules stay free of Android dependencies. Datasource modules implement domain contracts and can own DI
+bindings for their implementations when the binding fits the module's platform and Hilt component. UI modules depend
+on domain and shared UI helpers. Application-level setup, Android context providers, Android-specific Hilt components,
+and composition decisions stay in `app`.
 
 ## Presentation Pattern
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,6 @@ dependencies {
     implementation(libs.arrow.core)
 
     implementation(libs.hilt.android)
-    ksp(libs.kotlin.metadata.jvm)
     ksp(libs.hilt.android.compiler)
 
     implementation(libs.sqldelight.driver.android)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,14 +53,11 @@ dependencies {
     implementation(libs.arrow.core)
 
     implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
     ksp(libs.kotlin.metadata.jvm)
+    ksp(libs.hilt.android.compiler)
 
     implementation(libs.sqldelight.driver.android)
     implementation(libs.sqldelight.async.extensions)
-
-    implementation(platform(libs.ktor.bom))
-    implementation(libs.bundles.ktor)
 
     debugImplementation(libs.compose.ui.test.manifest)
 
@@ -75,5 +72,5 @@ dependencies {
     androidTestImplementation(platform(libs.junit.bom))
     androidTestImplementation(libs.junit.jupiter)
     androidTestImplementation(libs.hilt.android.testing)
-    kspAndroidTest(libs.hilt.compiler)
+    kspAndroidTest(libs.hilt.android.compiler)
 }

--- a/app/src/androidTest/java/com/matijasokol/githubapp/ui/RepoListEndToEnd.kt
+++ b/app/src/androidTest/java/com/matijasokol/githubapp/ui/RepoListEndToEnd.kt
@@ -18,12 +18,12 @@ import com.matijasokol.coreui.dictionary.DictionaryImpl
 import com.matijasokol.githubapp.MainActivity
 import com.matijasokol.githubapp.di.CacheModule
 import com.matijasokol.githubapp.di.CoreModule
-import com.matijasokol.githubapp.di.DataSourceModule
-import com.matijasokol.githubapp.di.NetworkModule
 import com.matijasokol.githubapp.di.ViewModelModule
 import com.matijasokol.githubapp.navigation.NavigationErrorMapper
 import com.matijasokol.githubapp.navigation.Navigator
 import com.matijasokol.githubapp.ui.theme.GitHubAppTheme
+import com.matijasokol.repo.datasource.di.DataSourceModule
+import com.matijasokol.repo.datasource.di.NetworkModule
 import com.matijasokol.repo.datasourcetest.cache.RepoCacheFake
 import com.matijasokol.repo.datasourcetest.cache.RepoDatabaseFake
 import com.matijasokol.repo.datasourcetest.network.FakePaginator

--- a/app/src/main/java/com/matijasokol/githubapp/di/CacheModule.kt
+++ b/app/src/main/java/com/matijasokol/githubapp/di/CacheModule.kt
@@ -22,8 +22,4 @@ object CacheModule {
         context = application,
         name = "repos.db",
     )
-
-    @Provides
-    @Singleton
-    fun provideRepoDatabase(sqlDriver: SqlDriver): RepoDatabase = RepoDatabase(sqlDriver)
 }

--- a/app/src/main/java/com/matijasokol/githubapp/di/ViewModelModule.kt
+++ b/app/src/main/java/com/matijasokol/githubapp/di/ViewModelModule.kt
@@ -14,5 +14,5 @@ abstract class ViewModelModule {
 
     @Binds
     @ViewModelScoped
-    abstract fun provideBasicPaginator(basicPaginator: BasicPaginator): Paginator
+    abstract fun bindPaginator(basicPaginator: BasicPaginator): Paginator
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,6 @@ kluent = { group = "org.amshove.kluent", name = "kluent", version.ref = "kluent"
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 konsist = { group = "com.lemonappdev", name = "konsist", version.ref = "konsist" }
 
-kotlin-metadata-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-metadata-jvm", version.ref = "kotlin" }
 kotlinx-serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,8 +85,10 @@ sqldelight-driver-android = { group = "app.cash.sqldelight", name = "android-dri
 sqldelight-coroutines = { group = "app.cash.sqldelight", name = "coroutines-extensions", version.ref = "sqldelight" }
 sqldelight-async-extensions = { group = "app.cash.sqldelight", name = "async-extensions", version.ref = "sqldelight" }
 
+hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hilt" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
-hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "javaxInject" }
 

--- a/repo/datasource/build.gradle.kts
+++ b/repo/datasource/build.gradle.kts
@@ -13,5 +13,8 @@ dependencies {
     implementation(libs.arrow.core)
     implementation(libs.arrow.coroutines)
 
+    implementation(libs.hilt.core)
+    ksp(libs.hilt.compiler)
+
     implementation(libs.javax.inject)
 }

--- a/repo/datasource/src/main/java/com/matijasokol/repo/datasource/di/DataSourceModule.kt
+++ b/repo/datasource/src/main/java/com/matijasokol/repo/datasource/di/DataSourceModule.kt
@@ -1,11 +1,14 @@
-package com.matijasokol.githubapp.di
+package com.matijasokol.repo.datasource.di
 
+import app.cash.sqldelight.db.SqlDriver
 import com.matijasokol.repo.datasource.cache.RepoCacheImpl
+import com.matijasokol.repo.datasource.cache.RepoDatabase
 import com.matijasokol.repo.datasource.network.RepoServiceImpl
 import com.matijasokol.repo.domain.RepoCache
 import com.matijasokol.repo.domain.RepoService
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
@@ -21,4 +24,11 @@ abstract class DataSourceModule {
     @Binds
     @Singleton
     abstract fun bindRepoCache(repoCacheImpl: RepoCacheImpl): RepoCache
+
+    companion object {
+
+        @Provides
+        @Singleton
+        fun provideRepoDatabase(sqlDriver: SqlDriver): RepoDatabase = RepoDatabase(sqlDriver)
+    }
 }

--- a/repo/datasource/src/main/java/com/matijasokol/repo/datasource/di/NetworkModule.kt
+++ b/repo/datasource/src/main/java/com/matijasokol/repo/datasource/di/NetworkModule.kt
@@ -1,4 +1,4 @@
-package com.matijasokol.githubapp.di
+package com.matijasokol.repo.datasource.di
 
 import com.matijasokol.repo.datasource.network.buildHttpClient
 import com.matijasokol.repo.datasource.network.json
@@ -18,7 +18,7 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideJson() = json
+    fun provideJson(): Json = json
 
     @Provides
     @Singleton

--- a/repo/detail/build.gradle.kts
+++ b/repo/detail/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(libs.arrow.coroutines)
 
     implementation(libs.hilt.android)
-    ksp(libs.kotlin.metadata.jvm)
     ksp(libs.hilt.android.compiler)
 
     debugImplementation(libs.compose.ui.test.manifest)

--- a/repo/detail/build.gradle.kts
+++ b/repo/detail/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
     implementation(libs.arrow.coroutines)
 
     implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
     ksp(libs.kotlin.metadata.jvm)
+    ksp(libs.hilt.android.compiler)
 
     debugImplementation(libs.compose.ui.test.manifest)
 

--- a/repo/list/build.gradle.kts
+++ b/repo/list/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(libs.arrow.coroutines)
 
     implementation(libs.hilt.android)
-    ksp(libs.kotlin.metadata.jvm)
     ksp(libs.hilt.android.compiler)
 
     debugImplementation(libs.compose.ui.test.manifest)

--- a/repo/list/build.gradle.kts
+++ b/repo/list/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
     implementation(libs.arrow.coroutines)
 
     implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
     ksp(libs.kotlin.metadata.jvm)
+    ksp(libs.hilt.android.compiler)
 
     debugImplementation(libs.compose.ui.test.manifest)
 


### PR DESCRIPTION
## Closes issue

Closes #192

## Changes

### Proposed solution

- Moves datasource-owned Hilt modules from `app` to `repo:datasource`.
- Keeps app-owned bindings in `app`, including Android context and app-level composition setup.
- Provides `RepoDatabase` from the datasource DI module while keeping the SQL driver in the app module.
- Adds Hilt support to `repo:datasource` and removes unnecessary KSP Kotlin metadata dependency usage.
- Updates DI documentation to clarify module ownership rules.

## Testing

- [ ] Added a test for the main behavior change
- [x] Existing tests cover this change
- [ ] No test needed (explain why):