### PR TITLE
Move localized UI strings from composables into UI state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ app/                     → Application module (entry point, app-level DI setup
 
 - Use Kotlin idioms: `data class`, `sealed interface`, extension functions, `when` expressions.
 - Prefer immutable data (`val`, `ImmutableList` from kotlinx-collections-immutable).
-- Use `@Stable` annotation on Compose state classes.
+- Let the Compose compiler infer stability. Add `@Stable` only when a state type contains fields Compose treats as unstable and the stability contract is valid; do not annotate immutable text or value models unnecessarily.
 - Do NOT use `var` in state classes; use `MutableStateFlow` + `.update {}` in ViewModels.
 - Keep functions small and single-purpose.
 
@@ -69,7 +69,7 @@ app/                     → Application module (entry point, app-level DI setup
 
 Each feature screen follows a strict **MVI** (Model-View-Intent) pattern:
 
-- **`*State`** — `@Stable data class` holding all UI state, using `ImmutableList` for collections.
+- **`*State`** — Immutable `data class` holding all UI state, using `ImmutableList` for collections. Use `@Stable` only when stability cannot be inferred safely.
 - **`*Event`** — `sealed interface` representing user intents/interactions sent TO the ViewModel.
 - **`*Action`** — `sealed interface` representing one-shot actions sent FROM the ViewModel to the UI (navigation, messages). Delivered via `Channel`.
 - **`*ViewModel`** — `@HiltViewModel` class exposing:
@@ -77,6 +77,7 @@ Each feature screen follows a strict **MVI** (Model-View-Intent) pattern:
   - `val actions: Flow<*Action>` (from `Channel.receiveAsFlow()`)
   - `fun onEvent(event: *Event)` as the single entry point for UI interactions.
 - **`*UiMapper`** — Separate class to map domain state to UI state (injected into ViewModel).
+- Screen composables may consume UI state. Child composables needing up to three text values should receive individual strings; when more than three text arguments are required, pass the relevant text state/model directly. Do not pass the entire screen state.
 
 ### Domain Layer
 
@@ -133,7 +134,7 @@ Each feature screen follows a strict **MVI** (Model-View-Intent) pattern:
 ### Don't
 
 - ❌ Don't add Android framework dependencies to `domain` or `core` modules.
-- ❌ Don't hardcode strings in UI — use `stringResource` in composables and the `Dictionary` abstraction in ViewModels or mappers.
+- ❌ Don't hardcode or resolve strings in composables. Use `strings.xml` → `Dictionary` → `UiMapper` → UI state/model → composable, including formatted and accessibility text.
 - ❌ Don't use `LiveData` — use `StateFlow` and `Channel` exclusively.
 - ❌ Don't use `mutableStateOf` in ViewModels — use `MutableStateFlow`.
 - ❌ Don't put business logic in Composables or ViewModels — extract to use cases.

--- a/README.md
+++ b/README.md
@@ -235,8 +235,12 @@ open pull requests per ecosystem.
 - Build configuration belongs in `build-logic/convention/`.
 - Dependency versions belong in `gradle/libs.versions.toml`.
 - Inter-module dependencies should use `projects.*` type-safe accessors.
-- UI strings should go through resources. Use `stringResource` in composables and the `Dictionary` abstraction where
-  strings are needed in ViewModels or mappers.
+- Resolve visible, formatted, and accessibility strings through `Dictionary` in UI mappers, then expose plain strings
+  through UI state or UI models. Composables must not access string resources directly.
+- At the screen boundary, pass child composables individual strings when they need up to three text values. Components
+  needing more than three may receive the relevant text state/model, but should not receive the entire screen state.
+- Let Compose infer stability for immutable state and UI models. Use `@Stable` only when inference is insufficient and
+  the type genuinely satisfies the stability contract.
 - Domain modules should remain pure Kotlin/JVM and free of Android, datasource, and UI dependencies.
 
 ## Konsist Architecture Checks
@@ -244,7 +248,8 @@ open pull requests per ecosystem.
 Konsist architecture tests live in `konsist/src/test/kotlin/com/matijasokol/githubapp/konsist` and inspect production sources with
 `Konsist.scopeFromProduction()`. The current rules cover package layer dependencies, domain and datasource boundaries,
 package naming and path matching, use case and ViewModel conventions, MVI companion declarations, UI model immutable
-collections, datasource DTO naming/serialization, Compose placement, data class immutability, and wildcard imports.
+collections, datasource DTO naming/serialization, Compose placement, localized string access, data class immutability,
+and wildcard imports.
 
 When adding or changing a rule, prefer a focused test class and avoid checks that duplicate ktlint or detekt unless
 Konsist adds project-specific value. Run `./gradlew konsist:test` locally, or `./gradlew test` to include Konsist with

--- a/app/src/main/java/com/matijasokol/githubapp/ui/AppContent.kt
+++ b/app/src/main/java/com/matijasokol/githubapp/ui/AppContent.kt
@@ -127,7 +127,12 @@ private fun RepoListEntry() {
                 action.repoFullName,
                 context,
             )
-            is RepoListAction.OpenProfile -> openProfile(action.profileUrl, uriHandler, context)
+            is RepoListAction.OpenProfile -> openProfile(
+                profileUrl = action.profileUrl,
+                errorMessage = state.text.profileBrowserErrorMessage,
+                uriHandler = uriHandler,
+                context = context,
+            )
             RepoListAction.ScrollToTop -> lazyStaggeredGridState.animateScrollToItem(0)
             is RepoListAction.ShowMessage -> Toast.makeText(context, action.message, Toast.LENGTH_SHORT).show()
         }
@@ -176,13 +181,13 @@ private suspend fun showDetails(
     }
 }
 
-fun openProfile(profileUrl: String, uriHandler: UriHandler, context: Context) {
+fun openProfile(profileUrl: String, errorMessage: String, uriHandler: UriHandler, context: Context) {
     try {
         uriHandler.openUri(profileUrl)
     } catch (_: Exception) {
         Toast.makeText(
             context,
-            context.getString(com.matijasokol.repo.list.R.string.repo_list_message_browser_error),
+            errorMessage,
             Toast.LENGTH_SHORT,
         ).show()
     }

--- a/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/PresentationKonsistTest.kt
+++ b/konsist/src/test/kotlin/com/matijasokol/githubapp/konsist/PresentationKonsistTest.kt
@@ -1,9 +1,17 @@
 package com.matijasokol.githubapp.konsist
 
+import com.lemonappdev.konsist.api.verify.assertFalse
 import com.lemonappdev.konsist.api.verify.assertTrue
 import org.junit.jupiter.api.Test
 
 class PresentationKonsistTest {
+
+    @Test
+    fun `production code does not resolve string resources in composables`() {
+        productionScope.imports.assertFalse { import ->
+            import.name == "androidx.compose.ui.res.stringResource"
+        }
+    }
 
     @Test
     fun `state and list UI models use ImmutableList for exposed collections`() {
@@ -29,6 +37,14 @@ class PresentationKonsistTest {
             .flatMap { viewModel -> viewModel.properties(includeNested = false) }
             .filter { property -> property.name == "actions" }
             .assertTrue { property -> property.text.contains(FLOW_TYPE_DECLARATION) }
+    }
+
+    @Test
+    fun `view models do not use Dictionary`() {
+        viewModelClasses()
+            .assertFalse { viewModel ->
+                viewModel.containingFile.hasImportWithName(DICTIONARY_IMPORT)
+            }
     }
 
     @Test
@@ -59,3 +75,4 @@ private const val PLAIN_LIST_TYPE_DECLARATION = ": List<"
 private const val IMMUTABLE_LIST_TYPE_DECLARATION = ": ImmutableList<"
 private const val STATE_FLOW_TYPE_DECLARATION = ": StateFlow<"
 private const val FLOW_TYPE_DECLARATION = ": Flow<"
+private const val DICTIONARY_IMPORT = "com.matijasokol.core.dictionary.Dictionary"

--- a/repo/detail/src/androidTest/java/com/matijasokol/repo/detail/ui/RepoDetailTest.kt
+++ b/repo/detail/src/androidTest/java/com/matijasokol/repo/detail/ui/RepoDetailTest.kt
@@ -5,21 +5,21 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.remember
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import androidx.test.core.app.ApplicationProvider
+import arrow.core.left
+import arrow.core.right
+import com.matijasokol.core.error.NetworkError
 import com.matijasokol.coreui.components.LocalSharedTransitionScope
 import com.matijasokol.coreui.dictionary.DictionaryImpl
 import com.matijasokol.repo.datasourcetest.network.serializeRepoResponseData
-import com.matijasokol.repo.detail.R
 import com.matijasokol.repo.detail.RepoDetail
 import com.matijasokol.repo.detail.RepoDetailState
-import com.matijasokol.repo.detail.RepoUi
+import com.matijasokol.repo.detail.RepoDetailsUiMapper
 import com.matijasokol.repo.detail.test.TAG_REPO_DETAIL_PROGRESS
-import kotlinx.collections.immutable.persistentListOf
 import org.junit.Rule
 import org.junit.Test
 
@@ -29,7 +29,9 @@ class RepoDetailTest {
     val composeTestRule = createComposeRule()
 
     private val repoData = serializeRepoResponseData(this::class.java.getResource("/repo_list_valid.json").readText())
+    private val repoFullName = "JetBrains/kotlin"
     private val dictionary = DictionaryImpl(ApplicationProvider.getApplicationContext())
+    private val uiMapper = RepoDetailsUiMapper(dictionary)
 
     // Workaround to provide required parameters due to shared transition animation
     // Without this, test will fail. See SharedElement.kt for more details
@@ -51,32 +53,14 @@ class RepoDetailTest {
     @Test
     fun repoDetailShownCorrectly() {
         val repo = repoData.random()
-        val detailsButtonText = dictionary.getString(R.string.repo_detail_btn_repo_details)
-        val infoData = with(dictionary) {
-            persistentListOf(
-                getString(R.string.repo_detail_panel_watchers, repo.watchersCount),
-                getString(R.string.repo_detail_panel_issues, repo.issuesCount),
-                getString(R.string.repo_detail_panel_forks, repo.forksCount),
-                getString(R.string.repo_detail_panel_stars, repo.starsCount),
-            )
-        }
+        val state = uiMapper.toUiState(
+            isLoading = false,
+            repoOrError = repo.right(),
+            repoFullName = repoFullName,
+            authorImageUrl = "",
+        ) as RepoDetailState.Success
 
         composeTestRule.setContent {
-            val state = remember {
-                RepoDetailState.Success(
-                    repoFullName = "JetBrains/kotlin",
-                    authorImageUrl = "",
-                    detailsButtonText = detailsButtonText,
-                    repoUi = RepoUi(
-                        followersCountText = null,
-                        reposCountText = null,
-                        authorProfileUrl = "",
-                        repoUrl = "",
-                        topics = persistentListOf(),
-                        info = infoData,
-                    ),
-                )
-            }
             FakeRootComposable {
                 RepoDetail(
                     state = state,
@@ -85,25 +69,23 @@ class RepoDetailTest {
             }
         }
 
-        composeTestRule.onNodeWithText(detailsButtonText, useUnmergedTree = true).assertExists()
+        composeTestRule.onNodeWithText(state.repositoryLinkTitle, useUnmergedTree = true).assertExists()
 
-        infoData.forEach { infoText ->
+        state.repoUi.info.forEach { infoText ->
             composeTestRule.onNodeWithText(infoText, useUnmergedTree = true).assertExists()
         }
     }
 
     @Test
     fun repoDetailErrorShowsErrorMessage() {
-        val errorMessageText = dictionary.getString(R.string.repo_detail_message_cache_error)
+        val state = uiMapper.toUiState(
+            isLoading = false,
+            repoOrError = NetworkError.UnknownNetworkError.left(),
+            repoFullName = repoFullName,
+            authorImageUrl = "",
+        ) as RepoDetailState.Error
 
         composeTestRule.setContent {
-            val state = remember {
-                RepoDetailState.Error(
-                    errorMessage = errorMessageText,
-                    repoFullName = "JetBrains/kotlin",
-                    authorImageUrl = "",
-                )
-            }
             FakeRootComposable {
                 RepoDetail(
                     state = state,
@@ -113,18 +95,14 @@ class RepoDetailTest {
         }
 
         composeTestRule.onNodeWithTag(TAG_REPO_DETAIL_PROGRESS).assertDoesNotExist()
-        composeTestRule.onNodeWithText(errorMessageText, useUnmergedTree = true).assertExists()
+        composeTestRule.onNodeWithText(state.loadErrorMessage, useUnmergedTree = true).assertExists()
     }
 
     @Test
     fun repoDetailLoadingShowsProgress() {
+        val state = uiMapper.loadingState(repoFullName = repoFullName, authorImageUrl = "")
+
         composeTestRule.setContent {
-            val state = remember {
-                RepoDetailState.Loading(
-                    repoFullName = "JetBrains/kotlin",
-                    authorImageUrl = "",
-                )
-            }
             FakeRootComposable {
                 RepoDetail(
                     state = state,

--- a/repo/detail/src/main/java/com/matijasokol/repo/detail/RepoDetail.kt
+++ b/repo/detail/src/main/java/com/matijasokol/repo/detail/RepoDetail.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -54,7 +53,12 @@ fun RepoDetail(
     ) {
         item {
             RepoHero(
-                state = state,
+                repoFullName = state.repoFullName,
+                authorImageUrl = state.authorImageUrl,
+                authorName = state.authorName,
+                repoName = state.repoName,
+                profileSupportingText = state.profileSupportingText,
+                profileEnabled = state is RepoDetailState.Success,
                 onProfileClick = {
                     try {
                         (state as? RepoDetailState.Success)?.repoUi?.authorProfileUrl?.let(uriHandler::openUri)
@@ -69,7 +73,7 @@ fun RepoDetail(
             is RepoDetailState.Error -> item {
                 Text(
                     modifier = Modifier.fillMaxWidth().padding(32.dp),
-                    text = state.errorMessage,
+                    text = state.loadErrorMessage,
                     color = MaterialTheme.colorScheme.error,
                     textAlign = TextAlign.Center,
                 )
@@ -87,7 +91,7 @@ fun RepoDetail(
                         modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
                     ) {
                         if (state.repoUi.topics.isNotEmpty()) {
-                            SectionLabel(stringResource(R.string.repo_detail_topics_label))
+                            SectionLabel(state.topicsSectionTitle)
                             LazyRow(
                                 contentPadding = PaddingValues(horizontal = 20.dp),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -107,8 +111,8 @@ fun RepoDetail(
                         }
 
                         RepositoryLinkCard(
-                            title = state.detailsButtonText,
-                            subtitle = stringResource(R.string.repo_detail_btn_repo_details_supporting),
+                            title = state.repositoryLinkTitle,
+                            subtitle = state.repositoryLinkSubtitle,
                             onClick = {
                                 try {
                                     uriHandler.openUri(state.repoUi.repoUrl)
@@ -119,7 +123,7 @@ fun RepoDetail(
                         )
 
                         SectionLabel(
-                            text = stringResource(R.string.repo_detail_overview_label),
+                            text = state.overviewSectionTitle,
                             modifier = Modifier.padding(top = 24.dp),
                         )
                         RepoDetailPanel(stats = state.repoUi.info)
@@ -131,7 +135,16 @@ fun RepoDetail(
 }
 
 @Composable
-private fun RepoHero(state: RepoDetailState, onProfileClick: () -> Unit) {
+@Suppress("LongParameterList")
+private fun RepoHero(
+    repoFullName: String,
+    authorImageUrl: String,
+    authorName: String,
+    repoName: String,
+    profileSupportingText: String,
+    profileEnabled: Boolean,
+    onProfileClick: () -> Unit,
+) {
     Surface(
         modifier = Modifier.fillMaxWidth().padding(20.dp),
         color = MaterialTheme.colorScheme.primaryContainer,
@@ -142,25 +155,25 @@ private fun RepoHero(state: RepoDetailState, onProfileClick: () -> Unit) {
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             RoundedImage(
-                modifier = Modifier.withSharedBounds(key = "${state.authorImageUrl}/${state.repoFullName}"),
-                imageUrl = state.authorImageUrl,
-                contentDescription = state.authorName,
+                modifier = Modifier.withSharedBounds(key = "$authorImageUrl/$repoFullName"),
+                imageUrl = authorImageUrl,
+                contentDescription = authorName,
                 size = 116.dp,
                 borderColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.16f),
                 borderWidth = 3.dp,
-                enabled = state is RepoDetailState.Success,
+                enabled = profileEnabled,
                 onClick = onProfileClick,
             )
             Spacer(modifier = Modifier.height(22.dp))
             Text(
-                modifier = Modifier.withSharedBounds(key = "${state.authorName}/${state.repoName}"),
-                text = state.repoFullName,
+                modifier = Modifier.withSharedBounds(key = "$authorName/$repoName"),
+                text = repoFullName,
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Black,
                 textAlign = TextAlign.Center,
             )
             Text(
-                text = stringResource(R.string.repo_detail_profile_label, state.authorName),
+                text = profileSupportingText,
                 color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.72f),
                 style = MaterialTheme.typography.bodyLarge,
             )

--- a/repo/detail/src/main/java/com/matijasokol/repo/detail/RepoDetailState.kt
+++ b/repo/detail/src/main/java/com/matijasokol/repo/detail/RepoDetailState.kt
@@ -2,40 +2,38 @@ package com.matijasokol.repo.detail
 
 import kotlinx.collections.immutable.ImmutableList
 
-sealed class RepoDetailState(
-    open val repoFullName: String,
-    open val authorImageUrl: String,
-) {
+sealed interface RepoDetailState {
+
+    val repoFullName: String
+    val authorImageUrl: String
+    val profileSupportingText: String
 
     val authorName: String get() = repoFullName.substringBefore("/")
     val repoName: String get() = repoFullName.substringAfter("/")
 
     data class Success(
         val repoUi: RepoUi,
-        val detailsButtonText: String,
+        val repositoryLinkTitle: String,
+        val repositoryLinkSubtitle: String,
+        val topicsSectionTitle: String,
+        val overviewSectionTitle: String,
         override val repoFullName: String,
         override val authorImageUrl: String,
-    ) : RepoDetailState(
-            repoFullName = repoFullName,
-            authorImageUrl = authorImageUrl,
-        )
+        override val profileSupportingText: String,
+    ) : RepoDetailState
 
     data class Error(
-        val errorMessage: String,
+        val loadErrorMessage: String,
         override val repoFullName: String,
         override val authorImageUrl: String,
-    ) : RepoDetailState(
-            repoFullName = repoFullName,
-            authorImageUrl = authorImageUrl,
-        )
+        override val profileSupportingText: String,
+    ) : RepoDetailState
 
     data class Loading(
         override val repoFullName: String,
         override val authorImageUrl: String,
-    ) : RepoDetailState(
-            repoFullName = repoFullName,
-            authorImageUrl = authorImageUrl,
-        )
+        override val profileSupportingText: String,
+    ) : RepoDetailState
 }
 
 data class RepoUi(

--- a/repo/detail/src/main/java/com/matijasokol/repo/detail/RepoDetailViewModel.kt
+++ b/repo/detail/src/main/java/com/matijasokol/repo/detail/RepoDetailViewModel.kt
@@ -2,7 +2,6 @@ package com.matijasokol.repo.detail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.matijasokol.core.dictionary.Dictionary
 import com.matijasokol.coreui.navigation.Destination
 import com.matijasokol.coreui.viewmodel.stateIn
 import com.matijasokol.repo.domain.usecase.GetRepoDetailsUseCase
@@ -27,8 +26,7 @@ import kotlinx.coroutines.launch
 class RepoDetailViewModel @AssistedInject constructor(
     @Assisted private val destination: Destination.RepoDetail,
     getRepoDetails: GetRepoDetailsUseCase,
-    uiMapper: RepoDetailsUiMapper,
-    private val dictionary: Dictionary,
+    private val uiMapper: RepoDetailsUiMapper,
 ) : ViewModel() {
 
     @AssistedFactory
@@ -54,28 +52,13 @@ class RepoDetailViewModel @AssistedInject constructor(
     ) { loading, repo ->
         uiMapper.toUiState(loading, repo, destination.repoFullName, destination.authorImageUrl)
     }.stateIn(
-        initialValue = RepoDetailState.Loading(
-            repoFullName = destination.repoFullName,
-            authorImageUrl = destination.authorImageUrl,
-        ),
+        initialValue = uiMapper.loadingState(destination.repoFullName, destination.authorImageUrl),
     )
 
     fun onEvent(event: RepoDetailEvent) {
         when (event) {
-            RepoDetailEvent.OpenProfileWebError -> viewModelScope.launch {
-                _actions.send(
-                    RepoDetailAction.ShowMessage(
-                        dictionary.getString(R.string.repo_detail_message_profile_browser_error),
-                    ),
-                )
-            }
-            RepoDetailEvent.OpenRepoWebError -> viewModelScope.launch {
-                _actions.send(
-                    RepoDetailAction.ShowMessage(
-                        dictionary.getString(R.string.repo_detail_message_repo_browser_error),
-                    ),
-                )
-            }
+            RepoDetailEvent.OpenProfileWebError, RepoDetailEvent.OpenRepoWebError ->
+                viewModelScope.launch { _actions.send(uiMapper.toAction(event)) }
         }
     }
 }

--- a/repo/detail/src/main/java/com/matijasokol/repo/detail/RepoDetailsUiMapper.kt
+++ b/repo/detail/src/main/java/com/matijasokol/repo/detail/RepoDetailsUiMapper.kt
@@ -13,14 +13,24 @@ import javax.inject.Inject
 class RepoDetailsUiMapper @Inject constructor(private val dictionary: Dictionary) {
 
     private data class DetailsStaticData(
-        val errorMessage: String,
-        val detailsButtonText: String,
+        val loadErrorMessage: String,
+        val repositoryLinkTitle: String,
+        val repositoryLinkSubtitle: String,
+        val topicsSectionTitle: String,
+        val overviewSectionTitle: String,
+        val profileBrowserErrorMessage: String,
+        val repoBrowserErrorMessage: String,
     )
 
     private val staticData by lazy {
         DetailsStaticData(
-            errorMessage = dictionary.getString(R.string.repo_detail_message_cache_error),
-            detailsButtonText = dictionary.getString(R.string.repo_detail_btn_repo_details),
+            loadErrorMessage = dictionary.getString(R.string.repo_detail_message_cache_error),
+            repositoryLinkTitle = dictionary.getString(R.string.repo_detail_btn_repo_details),
+            repositoryLinkSubtitle = dictionary.getString(R.string.repo_detail_btn_repo_details_supporting),
+            topicsSectionTitle = dictionary.getString(R.string.repo_detail_topics_label),
+            overviewSectionTitle = dictionary.getString(R.string.repo_detail_overview_label),
+            profileBrowserErrorMessage = dictionary.getString(R.string.repo_detail_message_profile_browser_error),
+            repoBrowserErrorMessage = dictionary.getString(R.string.repo_detail_message_repo_browser_error),
         )
     }
 
@@ -30,18 +40,19 @@ class RepoDetailsUiMapper @Inject constructor(private val dictionary: Dictionary
         repoFullName: String,
         authorImageUrl: String,
     ) = when (isLoading) {
-        true -> RepoDetailState.Loading(
-            repoFullName = repoFullName,
-            authorImageUrl = authorImageUrl,
-        )
+        true -> loadingState(repoFullName, authorImageUrl)
         false -> when (repoOrError) {
             is Either.Left -> RepoDetailState.Error(
-                errorMessage = staticData.errorMessage,
+                loadErrorMessage = staticData.loadErrorMessage,
                 repoFullName = repoFullName,
                 authorImageUrl = authorImageUrl,
+                profileSupportingText = profileSupportingText(repoFullName),
             )
             is Either.Right -> RepoDetailState.Success(
-                detailsButtonText = staticData.detailsButtonText,
+                repositoryLinkTitle = staticData.repositoryLinkTitle,
+                repositoryLinkSubtitle = staticData.repositoryLinkSubtitle,
+                topicsSectionTitle = staticData.topicsSectionTitle,
+                overviewSectionTitle = staticData.overviewSectionTitle,
                 repoUi = RepoUi(
                     repoUrl = repoOrError.value.url,
                     info = buildInfoData(repoOrError.value),
@@ -56,9 +67,28 @@ class RepoDetailsUiMapper @Inject constructor(private val dictionary: Dictionary
                 ),
                 repoFullName = repoFullName,
                 authorImageUrl = authorImageUrl,
+                profileSupportingText = profileSupportingText(repoFullName),
             )
         }
     }
+
+    fun loadingState(repoFullName: String, authorImageUrl: String) = RepoDetailState.Loading(
+        repoFullName = repoFullName,
+        authorImageUrl = authorImageUrl,
+        profileSupportingText = profileSupportingText(repoFullName),
+    )
+
+    fun toAction(event: RepoDetailEvent) = RepoDetailAction.ShowMessage(
+        message = when (event) {
+            RepoDetailEvent.OpenProfileWebError -> staticData.profileBrowserErrorMessage
+            RepoDetailEvent.OpenRepoWebError -> staticData.repoBrowserErrorMessage
+        },
+    )
+
+    private fun profileSupportingText(repoFullName: String) = dictionary.getString(
+        R.string.repo_detail_profile_label,
+        repoFullName.substringBefore("/"),
+    )
 
     private fun buildInfoData(repo: Repo): ImmutableList<String> = with(dictionary) {
         persistentListOf(

--- a/repo/detail/src/test/java/com/matijasokol/repo/detail/RepoDetailViewModelTest.kt
+++ b/repo/detail/src/test/java/com/matijasokol/repo/detail/RepoDetailViewModelTest.kt
@@ -29,7 +29,6 @@ class RepoDetailViewModelTest {
             destination = destination,
             getRepoDetails = getRepoDetailsUseCase,
             uiMapper = uiMapper,
-            dictionary = FakeDictionary(),
         )
 
         sut.state.test {
@@ -50,7 +49,6 @@ class RepoDetailViewModelTest {
             destination = destination,
             getRepoDetails = getRepoDetailsUseCase,
             uiMapper = uiMapper,
-            dictionary = FakeDictionary(),
         )
 
         sut.state.test {

--- a/repo/detail/src/test/java/com/matijasokol/repo/detail/RepoDetailsUiMapperTest.kt
+++ b/repo/detail/src/test/java/com/matijasokol/repo/detail/RepoDetailsUiMapperTest.kt
@@ -1,0 +1,33 @@
+package com.matijasokol.repo.detail
+
+import com.matijasokol.test.FakeDictionary
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class RepoDetailsUiMapperTest {
+
+    @Test
+    fun `should MAP static and formatted text`() {
+        val strings = mapOf(
+            R.string.repo_detail_message_cache_error to "Could not load details",
+            R.string.repo_detail_btn_repo_details to "View on GitHub",
+            R.string.repo_detail_btn_repo_details_supporting to "Open in browser",
+            R.string.repo_detail_topics_label to "Topics",
+            R.string.repo_detail_overview_label to "At a glance",
+            R.string.repo_detail_message_profile_browser_error to "Could not open profile",
+            R.string.repo_detail_message_repo_browser_error to "Could not open repository",
+        )
+        val sut = RepoDetailsUiMapper(
+            FakeDictionary(
+                getString = strings::getValue,
+                getStringArgs = { _, args -> "Maintained by ${args.single()}" },
+            ),
+        )
+
+        val state = sut.loadingState(repoFullName = "JetBrains/kotlin", authorImageUrl = "image")
+        val action = sut.toAction(RepoDetailEvent.OpenProfileWebError)
+
+        state.profileSupportingText.shouldBeEqualTo("Maintained by JetBrains")
+        action.message.shouldBeEqualTo("Could not open profile")
+    }
+}

--- a/repo/list/src/androidTest/java/com/matijasokol/repo/list/ui/RepoListTest.kt
+++ b/repo/list/src/androidTest/java/com/matijasokol/repo/list/ui/RepoListTest.kt
@@ -16,9 +16,9 @@ import com.matijasokol.coreui.dictionary.DictionaryImpl
 import com.matijasokol.repo.datasourcetest.network.serializeRepoResponseData
 import com.matijasokol.repo.domain.Paginator
 import com.matijasokol.repo.domain.model.Repo
-import com.matijasokol.repo.list.R
 import com.matijasokol.repo.list.RepoList
 import com.matijasokol.repo.list.RepoListState
+import com.matijasokol.repo.list.RepoListUiMapper
 import com.matijasokol.repo.list.test.TAG_LOADING_INDICATOR
 import com.matijasokol.repo.list.test.TAG_REPO_LIST_ITEM
 import com.matijasokol.repo.list.toRepoListItem
@@ -33,6 +33,7 @@ class RepoListTest {
 
     private val query = "kotlin"
     private val dictionary = DictionaryImpl(ApplicationProvider.getApplicationContext())
+    private val testText = RepoListUiMapper(dictionary).initialState(query).text
 
     // Workaround to provide required parameters due to shared transition animation
     // Without this, test will fail. See SharedElement.kt for more details
@@ -53,7 +54,7 @@ class RepoListTest {
 
     @Test
     fun repoListSuccessShowData() {
-        val errorText = dictionary.getString(R.string.repo_list_message_error)
+        val errorText = testText.loadErrorMessage
 
         val state = RepoListState(
             loadState = Paginator.LoadState.Loaded,
@@ -61,7 +62,7 @@ class RepoListTest {
             items = serializeRepoResponseData(
                 this::class.java.getResource("/repo_list_valid.json").readText(),
             ).map(Repo::toRepoListItem).toPersistentList(),
-            errorText = errorText,
+            text = testText,
         )
 
         composeTestRule.setContent {
@@ -88,13 +89,14 @@ class RepoListTest {
 
     @Test
     fun repoListEmptyShowErrorMessage() {
-        val errorText = dictionary.getString(R.string.repo_list_message_error)
+        val errorText = testText.loadErrorMessage
 
         composeTestRule.setContent {
             FakeRootComposable {
                 RepoList(
                     state = RepoListState(
                         query = query,
+                        text = testText,
                         items = serializeRepoResponseData(
                             this::class.java.getResource("/repo_list_empty.json").readText(),
                         ).map(Repo::toRepoListItem).toPersistentList(),
@@ -122,6 +124,7 @@ class RepoListTest {
                     state = RepoListState(
                         loadState = Paginator.LoadState.Refresh,
                         query = query,
+                        text = testText,
                     ),
                     onEvent = {},
                 )

--- a/repo/list/src/main/java/com/matijasokol/repo/list/RepoList.kt
+++ b/repo/list/src/main/java/com/matijasokol/repo/list/RepoList.kt
@@ -51,13 +51,13 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.kyant.backdrop.backdrops.layerBackdrop
 import com.kyant.backdrop.backdrops.rememberLayerBackdrop
+import com.matijasokol.repo.domain.Paginator.LoadState
 import com.matijasokol.repo.domain.Paginator.LoadState.Append
 import com.matijasokol.repo.domain.Paginator.LoadState.AppendError
 import com.matijasokol.repo.domain.Paginator.LoadState.Loaded
@@ -68,6 +68,7 @@ import com.matijasokol.repo.list.components.RepoListItem
 import com.matijasokol.repo.list.components.RepoSortBottomBar
 import com.matijasokol.repo.list.components.ShimmerRepoListItem
 import com.matijasokol.repo.list.test.TAG_LOADING_INDICATOR
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 
@@ -127,8 +128,8 @@ fun RepoList(
                 .layerBackdrop(backdrop),
         ) {
             RepoListHeader(
+                text = state.text,
                 queryValue = state.query,
-                queryLabel = state.queryLabel,
                 onQueryChanged = { onEvent(RepoListEvent.OnQueryChanged(it)) },
                 onClearClicked = { onEvent(RepoListEvent.OnQueryChanged("")) },
             )
@@ -138,13 +139,15 @@ fun RepoList(
                     Refresh -> LoadingContent()
                     RefreshError -> RetryContent(
                         modifier = Modifier.align(Alignment.Center),
-                        title = stringResource(R.string.repo_list_refresh_error_title),
-                        errorText = state.errorText,
-                        retryText = state.retryButtonText,
+                        title = state.text.refreshErrorTitle,
+                        errorText = state.text.loadErrorMessage,
+                        retryText = state.text.retryButtonText,
                         onRetryClick = { onEvent(RepoListEvent.OnRetryClick) },
                     )
                     Loaded, Append, AppendError -> ListScreen(
-                        state = state,
+                        repos = state.items,
+                        loadState = state.loadState,
+                        text = state.text,
                         lazyStaggeredGridState = lazyStaggeredGridState,
                         onItemClick = { onEvent(RepoListEvent.OnItemClick(it.authorImageUrl, it.fullName)) },
                         onImageClick = { onEvent(RepoListEvent.OnImageClick(it)) },
@@ -165,6 +168,7 @@ fun RepoList(
         ) {
             RepoSortBottomBar(
                 appliedSortType = state.repoSortType,
+                text = state.text.sortOptions,
                 backdrop = backdrop,
                 onSortTypeClicked = {
                     onEvent(RepoListEvent.UpdateSortType(it))
@@ -175,8 +179,11 @@ fun RepoList(
 }
 
 @Composable
+@Suppress("LongParameterList")
 private fun ListScreen(
-    state: RepoListState,
+    repos: ImmutableList<RepoListItem>,
+    loadState: LoadState,
+    text: RepoListText,
     lazyStaggeredGridState: LazyStaggeredGridState,
     onItemClick: (RepoListItem) -> Unit,
     onImageClick: (String) -> Unit,
@@ -196,21 +203,28 @@ private fun ListScreen(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalItemSpacing = 12.dp,
     ) {
-        items(items = state.items, key = RepoListItem::id) { repo ->
-            RepoListItem(repo = repo, onItemClick = onItemClick, onImageClick = onImageClick)
+        items(items = repos, key = RepoListItem::id) { repo ->
+            RepoListItem(
+                repo = repo,
+                watchersContentDescription = text.watchersIconContentDescription,
+                forksContentDescription = text.forksIconContentDescription,
+                issuesContentDescription = text.issuesIconContentDescription,
+                onItemClick = onItemClick,
+                onImageClick = onImageClick,
+            )
         }
-        if (state.loadState == Append) {
+        if (loadState == Append) {
             item(span = StaggeredGridItemSpan.FullLine) {
                 Box(modifier = Modifier.fillMaxWidth()) {
                     CircularProgressIndicator(modifier = Modifier.align(Alignment.Center).padding(16.dp))
                 }
             }
         }
-        if (state.loadState == AppendError) {
+        if (loadState == AppendError) {
             item(span = StaggeredGridItemSpan.FullLine) {
                 AppendRetryContent(
-                    errorText = state.errorText,
-                    retryText = state.retryButtonText,
+                    errorText = text.loadErrorMessage,
+                    retryText = text.retryButtonText,
                     onRetryClick = onRetryClick,
                 )
             }

--- a/repo/list/src/main/java/com/matijasokol/repo/list/RepoListState.kt
+++ b/repo/list/src/main/java/com/matijasokol/repo/list/RepoListState.kt
@@ -12,10 +12,8 @@ data class RepoListState(
     val loadState: Paginator.LoadState = Paginator.LoadState.Refresh,
     val items: ImmutableList<RepoListItem> = persistentListOf(),
     val query: String = "",
-    val queryLabel: String = "",
     val repoSortType: RepoSortType = RepoSortType.Unknown(),
-    val errorText: String = "",
-    val retryButtonText: String = "",
+    val text: RepoListText = RepoListText(),
 )
 
 data class RepoListItem(
@@ -28,6 +26,35 @@ data class RepoListItem(
     val watchers: String,
     val forks: String,
     val issues: String,
+)
+
+data class RepoListText(
+    val headerTitle: String = "",
+    val headerSubtitle: String = "",
+    val searchPlaceholder: String = "",
+    val searchIconContentDescription: String = "",
+    val clearSearchButtonContentDescription: String = "",
+    val refreshErrorTitle: String = "",
+    val loadErrorMessage: String = "",
+    val profileBrowserErrorMessage: String = "",
+    val retryButtonText: String = "",
+    val sortOptions: RepoSortText = RepoSortText(),
+    val watchersIconContentDescription: String = "",
+    val forksIconContentDescription: String = "",
+    val issuesIconContentDescription: String = "",
+)
+
+data class RepoSortText(
+    val sortOptionsContentDescription: String = "",
+    val starsOption: RepoSortOptionText = RepoSortOptionText(),
+    val forksOption: RepoSortOptionText = RepoSortOptionText(),
+    val updatedOption: RepoSortOptionText = RepoSortOptionText(),
+)
+
+data class RepoSortOptionText(
+    val displayLabel: String = "",
+    val ascendingActionContentDescription: String = "",
+    val descendingActionContentDescription: String = "",
 )
 
 fun Repo.toRepoListItem() = RepoListItem(

--- a/repo/list/src/main/java/com/matijasokol/repo/list/RepoListUiMapper.kt
+++ b/repo/list/src/main/java/com/matijasokol/repo/list/RepoListUiMapper.kt
@@ -9,17 +9,11 @@ import javax.inject.Inject
 
 class RepoListUiMapper @Inject constructor(private val dictionary: Dictionary) {
 
-    private data class ListStaticData(
-        val errorText: String,
-        val retryButtonText: String,
-    )
+    private data class ListStaticData(val text: RepoListText)
 
-    private val staticData by lazy {
-        ListStaticData(
-            errorText = dictionary.getString(R.string.repo_list_message_error),
-            retryButtonText = dictionary.getString(R.string.repo_list_retry_text),
-        )
-    }
+    private val staticData by lazy { ListStaticData(text = mapText()) }
+
+    fun initialState(query: String) = RepoListState(query = query, text = staticData.text)
 
     fun toUiState(
         loadState: Paginator.LoadState,
@@ -30,9 +24,54 @@ class RepoListUiMapper @Inject constructor(private val dictionary: Dictionary) {
         loadState = loadState,
         items = items.map(Repo::toRepoListItem).toPersistentList(),
         query = query,
-        queryLabel = dictionary.getString(R.string.repo_list_query_label),
         repoSortType = repoSortType,
-        errorText = staticData.errorText,
-        retryButtonText = staticData.retryButtonText,
+        text = staticData.text,
     )
+
+    private fun mapText(): RepoListText {
+        val ascending = dictionary.getString(R.string.repo_list_sort_ascending)
+        val descending = dictionary.getString(R.string.repo_list_sort_descending)
+
+        return RepoListText(
+            headerTitle = dictionary.getString(R.string.repo_list_title),
+            headerSubtitle = dictionary.getString(R.string.repo_list_subtitle),
+            searchPlaceholder = dictionary.getString(R.string.repo_list_query_label),
+            searchIconContentDescription = dictionary.getString(R.string.repo_list_search_content_description),
+            clearSearchButtonContentDescription = dictionary.getString(
+                R.string.repo_list_clear_search_content_description,
+            ),
+            refreshErrorTitle = dictionary.getString(R.string.repo_list_refresh_error_title),
+            loadErrorMessage = dictionary.getString(R.string.repo_list_message_error),
+            profileBrowserErrorMessage = dictionary.getString(R.string.repo_list_message_browser_error),
+            retryButtonText = dictionary.getString(R.string.repo_list_retry_text),
+            sortOptions = RepoSortText(
+                sortOptionsContentDescription = dictionary.getString(
+                    R.string.repo_list_sort_options_content_description,
+                ),
+                starsOption = mapSortOption(R.string.repo_list_sort_stars, ascending, descending),
+                forksOption = mapSortOption(R.string.repo_list_sort_forks, ascending, descending),
+                updatedOption = mapSortOption(R.string.repo_list_sort_updated, ascending, descending),
+            ),
+            watchersIconContentDescription = dictionary.getString(R.string.repo_list_watchers_content_description),
+            forksIconContentDescription = dictionary.getString(R.string.repo_list_forks_content_description),
+            issuesIconContentDescription = dictionary.getString(R.string.repo_list_issues_content_description),
+        )
+    }
+
+    private fun mapSortOption(labelResId: Int, ascending: String, descending: String): RepoSortOptionText {
+        val label = dictionary.getString(labelResId)
+        return RepoSortOptionText(
+            displayLabel = label,
+            ascendingActionContentDescription = dictionary.getString(
+                R.string.repo_list_sort_direction_content_description,
+                label,
+                ascending,
+            ),
+            descendingActionContentDescription = dictionary.getString(
+                R.string.repo_list_sort_direction_content_description,
+                label,
+                descending,
+            ),
+        )
+    }
 }

--- a/repo/list/src/main/java/com/matijasokol/repo/list/RepoListViewModel.kt
+++ b/repo/list/src/main/java/com/matijasokol/repo/list/RepoListViewModel.kt
@@ -55,7 +55,7 @@ class RepoListViewModel @Inject constructor(
         query,
         sortType,
         uiMapper::toUiState,
-    ).stateIn(initialValue = RepoListState(query = DEFAULT_QUERY))
+    ).stateIn(initialValue = uiMapper.initialState(query = DEFAULT_QUERY))
 
     fun onEvent(event: RepoListEvent) {
         when (event) {

--- a/repo/list/src/main/java/com/matijasokol/repo/list/components/RepoInfoPanel.kt
+++ b/repo/list/src/main/java/com/matijasokol/repo/list/components/RepoInfoPanel.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import com.matijasokol.repo.list.R
@@ -21,6 +20,9 @@ fun RepoInfoPanel(
     watchers: String,
     forks: String,
     issues: String,
+    watchersContentDescription: String,
+    forksContentDescription: String,
+    issuesContentDescription: String,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -30,17 +32,17 @@ fun RepoInfoPanel(
         RepoStat(
             text = watchers,
             icon = ImageVector.vectorResource(R.drawable.watch),
-            contentDescription = stringResource(R.string.repo_list_watchers_content_description),
+            contentDescription = watchersContentDescription,
         )
         RepoStat(
             text = forks,
             icon = ImageVector.vectorResource(R.drawable.fork),
-            contentDescription = stringResource(R.string.repo_list_forks_content_description),
+            contentDescription = forksContentDescription,
         )
         RepoStat(
             text = issues,
             icon = ImageVector.vectorResource(R.drawable.issue),
-            contentDescription = stringResource(R.string.repo_list_issues_content_description),
+            contentDescription = issuesContentDescription,
         )
     }
 }

--- a/repo/list/src/main/java/com/matijasokol/repo/list/components/RepoListHeader.kt
+++ b/repo/list/src/main/java/com/matijasokol/repo/list/components/RepoListHeader.kt
@@ -9,15 +9,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.matijasokol.repo.list.R
+import com.matijasokol.repo.list.RepoListText
 
 @Composable
 fun RepoListHeader(
+    text: RepoListText,
     queryValue: String,
-    queryLabel: String,
     onQueryChanged: (String) -> Unit,
     onClearClicked: () -> Unit,
     modifier: Modifier = Modifier,
@@ -28,19 +27,21 @@ fun RepoListHeader(
             .padding(horizontal = 20.dp, vertical = 12.dp),
     ) {
         Text(
-            text = stringResource(R.string.repo_list_title),
+            text = text.headerTitle,
             style = MaterialTheme.typography.headlineLarge,
             fontWeight = FontWeight.Black,
         )
         Text(
-            text = stringResource(R.string.repo_list_subtitle),
+            text = text.headerSubtitle,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             style = MaterialTheme.typography.bodyLarge,
         )
         Spacer(modifier = Modifier.height(16.dp))
         SearchBar(
             text = queryValue,
-            placeholderText = queryLabel,
+            placeholderText = text.searchPlaceholder,
+            searchContentDescription = text.searchIconContentDescription,
+            clearSearchContentDescription = text.clearSearchButtonContentDescription,
             onTextChanged = onQueryChanged,
             onClearClicked = onClearClicked,
         )

--- a/repo/list/src/main/java/com/matijasokol/repo/list/components/RepoListItem.kt
+++ b/repo/list/src/main/java/com/matijasokol/repo/list/components/RepoListItem.kt
@@ -28,6 +28,9 @@ import com.matijasokol.repo.list.test.TAG_REPO_LIST_ITEM
 @Composable
 fun RepoListItem(
     repo: RepoListItem,
+    watchersContentDescription: String,
+    forksContentDescription: String,
+    issuesContentDescription: String,
     onItemClick: (RepoListItem) -> Unit,
     onImageClick: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -79,6 +82,9 @@ fun RepoListItem(
                 watchers = repo.watchers,
                 forks = repo.forks,
                 issues = repo.issues,
+                watchersContentDescription = watchersContentDescription,
+                forksContentDescription = forksContentDescription,
+                issuesContentDescription = issuesContentDescription,
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/repo/list/src/main/java/com/matijasokol/repo/list/components/RepoSortBottomBar.kt
+++ b/repo/list/src/main/java/com/matijasokol/repo/list/components/RepoSortBottomBar.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -42,11 +41,13 @@ import com.kyant.backdrop.effects.vibrancy
 import com.matijasokol.core.domain.SortOrder
 import com.matijasokol.repo.domain.RepoSortType
 import com.matijasokol.repo.list.R
+import com.matijasokol.repo.list.RepoSortText
 import kotlinx.coroutines.launch
 
 @Composable
 fun RepoSortBottomBar(
     appliedSortType: RepoSortType,
+    text: RepoSortText,
     backdrop: Backdrop,
     modifier: Modifier = Modifier,
     onSortTypeClicked: (RepoSortType) -> Unit,
@@ -54,7 +55,6 @@ fun RepoSortBottomBar(
     val scope = rememberCoroutineScope()
     val pressProgress = remember { Animatable(0f) }
     val containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.62f)
-    val contentDescription = stringResource(R.string.repo_list_sort_options_content_description)
 
     Row(
         modifier = modifier
@@ -83,27 +83,33 @@ fun RepoSortBottomBar(
             }
             .height(64.dp)
             .fillMaxWidth()
-            .semantics { this.contentDescription = contentDescription }
+            .semantics { contentDescription = text.sortOptionsContentDescription }
             .padding(4.dp),
         horizontalArrangement = Arrangement.spacedBy(2.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         SortOption(
-            label = stringResource(R.string.repo_list_sort_stars),
+            label = text.starsOption.displayLabel,
+            ascendingContentDescription = text.starsOption.ascendingActionContentDescription,
+            descendingContentDescription = text.starsOption.descendingActionContentDescription,
             selected = appliedSortType is RepoSortType.Stars,
             order = appliedSortType.order,
             modifier = Modifier.weight(1f).fillMaxHeight(),
             onOrderClick = { onSortTypeClicked(RepoSortType.Stars(it)) },
         )
         SortOption(
-            label = stringResource(R.string.repo_list_sort_forks),
+            label = text.forksOption.displayLabel,
+            ascendingContentDescription = text.forksOption.ascendingActionContentDescription,
+            descendingContentDescription = text.forksOption.descendingActionContentDescription,
             selected = appliedSortType is RepoSortType.Forks,
             order = appliedSortType.order,
             modifier = Modifier.weight(1f).fillMaxHeight(),
             onOrderClick = { onSortTypeClicked(RepoSortType.Forks(it)) },
         )
         SortOption(
-            label = stringResource(R.string.repo_list_sort_updated),
+            label = text.updatedOption.displayLabel,
+            ascendingContentDescription = text.updatedOption.ascendingActionContentDescription,
+            descendingContentDescription = text.updatedOption.descendingActionContentDescription,
             selected = appliedSortType is RepoSortType.Updated,
             order = appliedSortType.order,
             modifier = Modifier.weight(1f).fillMaxHeight(),
@@ -115,6 +121,8 @@ fun RepoSortBottomBar(
 @Composable
 private fun SortOption(
     label: String,
+    ascendingContentDescription: String,
+    descendingContentDescription: String,
     selected: Boolean,
     order: SortOrder,
     modifier: Modifier = Modifier,
@@ -132,14 +140,14 @@ private fun SortOption(
     ) {
         Row(modifier = Modifier.matchParentSize()) {
             DirectionAction(
-                label = label,
+                contentDescription = ascendingContentDescription,
                 order = SortOrder.Ascending,
                 selected = selected && order == SortOrder.Ascending,
                 modifier = Modifier.weight(1f).fillMaxHeight(),
                 onClick = { onOrderClick(SortOrder.Ascending) },
             )
             DirectionAction(
-                label = label,
+                contentDescription = descendingContentDescription,
                 order = SortOrder.Descending,
                 selected = selected && order == SortOrder.Descending,
                 modifier = Modifier.weight(1f).fillMaxHeight(),
@@ -157,18 +165,12 @@ private fun SortOption(
 
 @Composable
 private fun DirectionAction(
-    label: String,
+    contentDescription: String,
     order: SortOrder,
     selected: Boolean,
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
 ) {
-    val direction = stringResource(
-        when (order) {
-            SortOrder.Ascending -> R.string.repo_list_sort_ascending
-            SortOrder.Descending -> R.string.repo_list_sort_descending
-        },
-    )
     val contentColor = when (selected) {
         true -> MaterialTheme.colorScheme.primary
         false -> MaterialTheme.colorScheme.onSurfaceVariant
@@ -187,7 +189,7 @@ private fun DirectionAction(
                 .size(36.dp)
                 .clip(RoundedCornerShape(18.dp))
                 .clickable(onClick = onClick)
-                .semantics { contentDescription = "$label $direction" },
+                .semantics { this.contentDescription = contentDescription },
             contentAlignment = Alignment.Center,
         ) {
             Icon(

--- a/repo/list/src/main/java/com/matijasokol/repo/list/components/SearchBar.kt
+++ b/repo/list/src/main/java/com/matijasokol/repo/list/components/SearchBar.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import com.matijasokol.repo.list.R
@@ -31,6 +30,8 @@ import com.matijasokol.repo.list.R
 fun SearchBar(
     text: String,
     placeholderText: String,
+    searchContentDescription: String,
+    clearSearchContentDescription: String,
     onTextChanged: (String) -> Unit,
     onClearClicked: () -> Unit,
     modifier: Modifier = Modifier,
@@ -60,7 +61,7 @@ fun SearchBar(
                     ) {
                         Icon(
                             imageVector = ImageVector.vectorResource(id = R.drawable.search),
-                            contentDescription = stringResource(R.string.repo_list_search_content_description),
+                            contentDescription = searchContentDescription,
                             modifier = Modifier.minimumInteractiveComponentSize(),
                             tint = MaterialTheme.colorScheme.primary,
                         )
@@ -93,9 +94,7 @@ fun SearchBar(
                             ) {
                                 Icon(
                                     imageVector = ImageVector.vectorResource(id = R.drawable.clear),
-                                    contentDescription = stringResource(
-                                        R.string.repo_list_clear_search_content_description,
-                                    ),
+                                    contentDescription = clearSearchContentDescription,
                                 )
                             }
                         }

--- a/repo/list/src/main/res/values/strings.xml
+++ b/repo/list/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="repo_list_sort_updated">Updated</string>
     <string name="repo_list_sort_ascending">Ascending</string>
     <string name="repo_list_sort_descending">Descending</string>
+    <string name="repo_list_sort_direction_content_description">%1$s %2$s</string>
 
     <string name="repo_list_query_label">Search</string>
 

--- a/repo/list/src/test/java/com/matijasokol/repo/list/RepoListUiMapperTest.kt
+++ b/repo/list/src/test/java/com/matijasokol/repo/list/RepoListUiMapperTest.kt
@@ -1,0 +1,47 @@
+package com.matijasokol.repo.list
+
+import com.matijasokol.test.FakeDictionary
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class RepoListUiMapperTest {
+
+    @Test
+    fun `should MAP static and formatted text to initial state`() {
+        val strings = mapOf(
+            R.string.repo_list_sort_ascending to "Ascending",
+            R.string.repo_list_sort_descending to "Descending",
+            R.string.repo_list_title to "Discover",
+            R.string.repo_list_subtitle to "Repositories worth exploring",
+            R.string.repo_list_query_label to "Search repositories",
+            R.string.repo_list_search_content_description to "Search",
+            R.string.repo_list_clear_search_content_description to "Clear",
+            R.string.repo_list_refresh_error_title to "Could not load repositories",
+            R.string.repo_list_message_error to "Loading failed",
+            R.string.repo_list_message_browser_error to "Could not open profile",
+            R.string.repo_list_retry_text to "Retry",
+            R.string.repo_list_sort_options_content_description to "Sort options",
+            R.string.repo_list_sort_stars to "Stars",
+            R.string.repo_list_sort_forks to "Forks",
+            R.string.repo_list_sort_updated to "Updated",
+            R.string.repo_list_watchers_content_description to "Watchers",
+            R.string.repo_list_forks_content_description to "Forks",
+            R.string.repo_list_issues_content_description to "Issues",
+        )
+        val sut = RepoListUiMapper(
+            FakeDictionary(
+                getString = strings::getValue,
+                getStringArgs = { _, args -> args.joinToString(" ") },
+            ),
+        )
+
+        val state = sut.initialState(query = "kotlin")
+
+        state.text.headerTitle.shouldBeEqualTo("Discover")
+        state.text.searchIconContentDescription.shouldBeEqualTo("Search")
+        state.text.profileBrowserErrorMessage.shouldBeEqualTo("Could not open profile")
+        state.text.sortOptions.forksOption.displayLabel.shouldBeEqualTo("Forks")
+        state.text.sortOptions.forksOption.ascendingActionContentDescription.shouldBeEqualTo("Forks Ascending")
+        state.text.sortOptions.forksOption.descendingActionContentDescription.shouldBeEqualTo("Forks Descending")
+    }
+}


### PR DESCRIPTION
## Closes issue

Closes #199

## Changes

### Proposed solution

- Resolves visible, formatted, and accessibility strings through feature UI mappers.
- Exposes localized text through repository list and detail UI state models.
- Removes direct `stringResource` usage from production composables.
- Moves browser error messages from resource lookups into mapped state and actions.
- Adds a Konsist rule preventing string-resource resolution in production composables.
- Updates localization and Compose stability conventions in project documentation.

## Testing

- [x] Added mapper tests for static and formatted localized text.
- [x] Updated affected Compose UI and ViewModel tests.